### PR TITLE
Fix Class 'Lorisleiva\Actions\EventDispatcherDecorator' not found

### DIFF
--- a/src/EventDispatcherDecorator.php
+++ b/src/EventDispatcherDecorator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LorisLeiva\Actions;
+namespace Lorisleiva\Actions;
 
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;


### PR DESCRIPTION
Fix Class 'Lorisleiva\Actions\EventDispatcherDecorator' not found on composer install, update and dump-autoload etc. for case sensitive file systems, caused by a typo in the vendor name of the package.