### PR TITLE
Clear cached Event Facade instance

### DIFF
--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Lorisleiva\Actions;
 
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Lorisleiva\Actions\Commands\MakeActionCommand;
@@ -12,6 +13,7 @@ class ActionServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        Facade::clearResolvedInstance('events');
         $this->app->extend('events', function ($dispatcher, $app) {
             return new EventDispatcherDecorator($dispatcher, $app);
         });


### PR DESCRIPTION
Ensure that EventDispatcherDecorator is used for future calls to Event::listen().

Fixes an issue where Event::listen() would use the standard EventDispatcher in stead of EventDispatcherDecorator.

Other ServiceProviders (e.g. PassportServiceProvider) may use the Event facade before this package is booted, resulting in the standard EventDispatcher being cached and used in all future calls to Event::listen().

Clearing the cached instance allows an EventDispatcherDecorator instance to be resolved and cached the next time the Event Facade is used.