### PR TITLE
Avoid instantiating every listener to check if is a subclass of Action.

### DIFF
--- a/src/EventDispatcherDecorator.php
+++ b/src/EventDispatcherDecorator.php
@@ -38,44 +38,44 @@ class EventDispatcherDecorator implements DispatcherContract
             return false;
         }
 
-        return $this->container->make($class) instanceof Action;
+        return false !== in_array(Action::class, \class_parents($class));
     }
-    
+
     public function hasListeners($eventName)
     {
         return $this->dispatcher->hasListeners($eventName);
     }
-    
+
     public function subscribe($subscriber)
     {
         return $this->dispatcher->subscribe($subscriber);
     }
-    
+
     public function until($event, $payload = [])
     {
         return $this->dispatcher->until($event, $payload);
     }
-    
+
     public function dispatch($event, $payload = [], $halt = false)
     {
         return $this->dispatcher->dispatch($event, $payload, $halt);
     }
-    
+
     public function push($event, $payload = [])
     {
         return $this->dispatcher->push($event, $payload);
     }
-    
+
     public function flush($event)
     {
         return $this->dispatcher->flush($event);
     }
-    
+
     public function forget($event)
     {
         return $this->dispatcher->forget($event);
     }
-    
+
     public function forgetPushed()
     {
         return $this->dispatcher->forgetPushed();


### PR DESCRIPTION
I notice that in every request `laravel-actions` were instantiating every single listener in order to verify if it was a sub-class of `Lorisleiva\Actions\Action`. 

Using PHP's `is_a ` to verify if the listener is an `Action` in the `EventDispatcherDecorator` might reduce the overhead of resolving it from the application container along with all of its dependency in every request. 