### PR TITLE
Fix paths on Windows

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -22,7 +22,7 @@ class ActionManager
      */
     public function __construct()
     {
-        $this->paths('app/Actions');
+        $this->paths('app'.DIRECTORY_SEPARATOR.'Actions');
         $this->registeredActions = collect();
     }
 


### PR DESCRIPTION
Actions were not registered correctly on Windows machines.
The `getClassnameFromPathname` method returned the absolute file path in stead of the class name, due to a mismatch of directory separators.