### PR TITLE
Add `static` docblock for run method

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -14,6 +14,7 @@ use ReflectionMethod;
 
 /**
  * @method mixed run(...$mixed)
+ * @method static mixed run(...$mixed)
  */
 abstract class Action
 {


### PR DESCRIPTION
Per the docs for [running an action as an object](https://laravelactions.com/actions-as-objects.html), the `run` method can be called either on the instance or as a static method, so the docblocks should represent both so that tooling and static analysis can pick up on it.