### PR TITLE
Fixes ignored default values in handle method.

### DIFF
--- a/tests/Actions/SimpleCalculatorWithHandleDefaults.php
+++ b/tests/Actions/SimpleCalculatorWithHandleDefaults.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\Actions;
+
+use Lorisleiva\Actions\Action;
+
+class SimpleCalculatorWithHandleDefaults extends SimpleCalculator
+{
+    protected $getAttributesFromConstructor = true;
+
+    public function handle($operation, $left = 50, $right = 100)
+    {
+        return parent::handle($operation, $left, $right);
+    }
+}

--- a/tests/RegistersActionsTest.php
+++ b/tests/RegistersActionsTest.php
@@ -10,6 +10,8 @@ use ReflectionClass;
 
 class RegistersActionsTest extends TestCase
 {
+    const ACTION_COUNT = 11;
+
     protected function getEnvironmentSetUp($app)
     {
         $app->instance(ActionManager::class, new class() extends ActionManager {
@@ -30,7 +32,7 @@ class RegistersActionsTest extends TestCase
         Actions::paths(__DIR__ . '/Actions');
         Actions::registerAllPaths();
 
-        $this->assertCount(10, Actions::getRegisteredActions());
+        $this->assertCount(static::ACTION_COUNT, Actions::getRegisteredActions());
     }
 
     /** @test */
@@ -40,7 +42,7 @@ class RegistersActionsTest extends TestCase
         Actions::registerAllPaths();
         Actions::registerAllPaths();
 
-        $this->assertCount(10, Actions::getRegisteredActions());
+        $this->assertCount(static::ACTION_COUNT, Actions::getRegisteredActions());
     }
 
     /** @test */

--- a/tests/RunsAsObjectsTest.php
+++ b/tests/RunsAsObjectsTest.php
@@ -5,6 +5,7 @@ namespace Lorisleiva\Actions\Tests;
 use BadMethodCallException;
 use Lorisleiva\Actions\Action;
 use Lorisleiva\Actions\Tests\Actions\SimpleCalculator;
+use Lorisleiva\Actions\Tests\Actions\SimpleCalculatorWithHandleDefaults;
 
 class RunsAsObjectsTest extends TestCase
 {
@@ -88,6 +89,19 @@ class RunsAsObjectsTest extends TestCase
         $this->assertEquals('addition', $action->operation);
         $this->assertEquals(3, $action->left);
         $this->assertEquals(5, $action->right);
+    }
+
+    /** @test */
+    public function it_can_fill_attributes_dynamically_from_handle()
+    {
+        $action = (new SimpleCalculatorWithHandleDefaults())->fill([
+            'operation' => 'addition',
+        ]);
+
+        $this->assertEquals('addition', $action->operation);
+        $this->assertEquals(50, $action->left);
+        $this->assertEquals(100, $action->right);
+        $this->assertEquals(150, $action->run());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #61 

- Always call `resolveAttributesFromConstructor` in the constructor to account for possible
  attributes in handle signature.
- Treat attributes in `handle` and attributes in `getAttributesFromConstructor` separately.
- Normalize return value to `$this` in `resolveAttributesFromConstructor`