### PR TITLE
Ensure models are serialized correctly within attributes

### DIFF
--- a/src/Concerns/SerializesModels.php
+++ b/src/Concerns/SerializesModels.php
@@ -9,6 +9,8 @@ trait SerializesModels
     use BaseSerializesModels {
         __sleep as protected sleepFromBaseSerializesModels;
         __wakeup as protected wakeupFromBaseSerializesModels;
+        __serialize as protected serializeFromBaseSerializesModels;
+        __unserialize as protected unserializeFromBaseSerializesModels;
     }
 
     public function __sleep()
@@ -29,6 +31,24 @@ trait SerializesModels
     public function __wakeup()
     {
         $this->wakeupFromBaseSerializesModels();
+
+        array_walk($this->attributes, function (&$value) {
+            $value = $this->getRestoredPropertyValue($value);
+        });
+    }
+
+    public function __serialize()
+    {
+        array_walk($this->attributes, function (&$value) {
+            $value = $this->getSerializedPropertyValue($value);
+        });
+
+        return $this->serializeFromBaseSerializesModels();
+    }
+
+    public function __unserialize(array $values)
+    {
+        $this->unserializeFromBaseSerializesModels($values);
 
         array_walk($this->attributes, function (&$value) {
             $value = $this->getRestoredPropertyValue($value);

--- a/src/Concerns/SerializesModels.php
+++ b/src/Concerns/SerializesModels.php
@@ -8,16 +8,30 @@ trait SerializesModels
 {
     use BaseSerializesModels {
         __sleep as protected sleepFromBaseSerializesModels;
+        __wakeup as protected wakeupFromBaseSerializesModels;
     }
 
     public function __sleep()
     {
         $properties = $this->sleepFromBaseSerializesModels();
 
+        array_walk($this->attributes, function (&$value) {
+            $value = $this->getSerializedPropertyValue($value);
+        });
+
         return array_values(array_diff($properties, [
             'request', 'runningAs', 'actingAs', 'errorBag', 'validator',
             'commandInstance', 'commandSignature', 'commandDescription',
             'getAttributesFromConstructor',
         ]));
+    }
+
+    public function __wakeup()
+    {
+        $this->wakeupFromBaseSerializesModels();
+
+        array_walk($this->attributes, function (&$value) {
+            $value = $this->getRestoredPropertyValue($value);
+        });
     }
 }

--- a/tests/SerializesModelsTest.php
+++ b/tests/SerializesModelsTest.php
@@ -4,6 +4,7 @@ namespace Lorisleiva\Actions\Tests;
 
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Lorisleiva\Actions\Tests\Actions\UpdateProfileDetails;
+use Lorisleiva\Actions\Tests\Stubs\User;
 
 class SerializesModelsTest extends TestCase
 {
@@ -37,11 +38,19 @@ class SerializesModelsTest extends TestCase
             'name' => 'Action San',
         ]);
 
+        // We want to be sure we have fetched the user from the DB
+        // rather than straight up unserializing into the class.
+        $hasBeenRetrieved = false;
+        User::retrieved(function () use (&$hasBeenRetrieved) {
+            $hasBeenRetrieved = true;
+        });
+
         $action = new UpdateProfileDetails(['user' => $user, 'name' => 'Laravel San']);
         $rehydratedAction = unserialize(serialize($action));
 
         $this->assertTrue(
             $user->is($rehydratedAction->get('user'))
         );
+        $this->assertTrue($hasBeenRetrieved);
     }
 }

--- a/tests/SerializesModelsTest.php
+++ b/tests/SerializesModelsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use Lorisleiva\Actions\Tests\Actions\UpdateProfileDetails;
+
+class SerializesModelsTest extends TestCase
+{
+    use SerializesAndRestoresModelIdentifiers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations();
+    }
+
+    /** @test */
+    public function it_serializes_models_within_action_attributes()
+    {
+        $user = $this->createUser([
+            'name' => 'Action San',
+        ]);
+
+        $action = new UpdateProfileDetails(['user' => $user, 'name' => 'Laravel San']);
+
+        $this->assertNotFalse(
+            strpos(serialize($action), serialize($this->getSerializedPropertyValue($user)))
+        );
+    }
+
+    /** @test */
+    public function it_unserializes_models_within_action_attributes()
+    {
+        $user = $this->createUser([
+            'name' => 'Action San',
+        ]);
+
+        $action = new UpdateProfileDetails(['user' => $user, 'name' => 'Laravel San']);
+        $rehydratedAction = unserialize(serialize($action));
+
+        $this->assertTrue(
+            $user->is($rehydratedAction->get('user'))
+        );
+    }
+}


### PR DESCRIPTION
Closes #55.

This PR adds additional prep work during `sleep` and `wakeup` methods to correctly serialize models and collections within the attributes array.

These changes will ensure the payload of jobs remain as small as possible.

These changes _may_ be breaking in some cases. Previously a model would have been serialized like a regular class, meaning should you have changed some model attributes and not persisted them then the job would be run with those un-persisted changes. After these changes, the model will be fetched from the database, fresh, when the model is unserialized. It's unlikely but a consideration non-the-less.
