### PR TITLE
Fix deprecation error with PHP 8

### DIFF
--- a/src/Concerns/ResolvesMethodDependencies.php
+++ b/src/Concerns/ResolvesMethodDependencies.php
@@ -5,6 +5,7 @@ namespace Lorisleiva\Actions\Concerns;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
+use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
 
@@ -35,7 +36,9 @@ trait ResolvesMethodDependencies
     protected function resolveDependency(ReflectionParameter $parameter, $extras = [])
     {
         list($key, $value) = $this->findAttributeFromParameter($parameter->name, $extras);
-        $class = $parameter->getClass();
+        $class = $parameter->getType() && !$parameter->getType()->isBuiltin()
+            ? new ReflectionClass($parameter->getType()->getName())
+            : null;
 
         if ($key && (! $class || $value instanceof $class->name)) {
             return $value;


### PR DESCRIPTION
As explained here: https://php.watch/versions/8.0/deprecated-reflectionparameter-methods#getClass

Works also with my local Laravel project based on PHP 7.4