### PR TITLE
Ignore view template files when registering action routes

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -132,9 +132,13 @@ class ActionManager
         }
 
         foreach ((new Finder)->in($paths->toArray())->files() as $file) {
-            $this->registerRoutesForAction(
-                $this->getClassnameFromPathname($file->getPathname())
-            );
+            $isView = Str::endsWith($file->getPathname(), ['blade.php', 'twig', 'html']) ;
+
+            if(!$isView){
+                $this->registerRoutesForAction(
+                    $this->getClassnameFromPathname($file->getPathname())
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Hi,

I got an error when I put my views files within the same folder with actions when registering the routes.

<img width="285" alt="Screen Shot 2021-02-11 at 3 14 43 AM" src="https://user-images.githubusercontent.com/1885785/107590704-e3fe2d00-6c19-11eb-95bb-cb1f4cc91aa8.png">

<img width="1030" alt="Screen Shot 2021-02-11 at 3 15 52 AM" src="https://user-images.githubusercontent.com/1885785/107590706-e52f5a00-6c19-11eb-81de-cb07b2bdc45b.png">

This is a suggested fix to check if the file is not a view.