### PR TITLE
Add optional support for unified attributes

### DIFF
--- a/src/ActionRequest.php
+++ b/src/ActionRequest.php
@@ -16,7 +16,11 @@ class ActionRequest extends FormRequest
 
     public function resolve()
     {
-        $this->setDefaultValidationData($this->all());
         $this->validate();
+    }
+
+    public function getDefaultValidationData(): array
+    {
+        return $this->all();
     }
 }

--- a/src/ActionRequest.php
+++ b/src/ActionRequest.php
@@ -14,11 +14,6 @@ class ActionRequest extends FormRequest
         // Cancel the auto-resolution trait.
     }
 
-    public function resolve()
-    {
-        $this->validate();
-    }
-
     public function getDefaultValidationData(): array
     {
         return $this->all();

--- a/src/ActionRequest.php
+++ b/src/ActionRequest.php
@@ -35,7 +35,7 @@ class ActionRequest extends FormRequest
         }
     }
 
-    protected function getValidatorInstance()
+    protected function getValidatorInstance(): Validator
     {
         if ($this->validator) {
             return $this->validator;
@@ -64,7 +64,7 @@ class ActionRequest extends FormRequest
         return $this->validator;
     }
 
-    protected function createDefaultValidator(ValidationFactory $factory)
+    protected function createDefaultValidator(ValidationFactory $factory): Validator
     {
         return $factory->make(
             $this->validationData(),
@@ -74,28 +74,28 @@ class ActionRequest extends FormRequest
         );
     }
 
-    public function validationData()
+    public function validationData(): array
     {
         return $this->hasMethod('getValidationData')
             ? $this->resolveAndCallMethod('getValidationData')
             : $this->all();
     }
 
-    public function rules()
+    public function rules(): array
     {
         return $this->hasMethod('rules')
             ? $this->resolveAndCallMethod('rules')
             : [];
     }
 
-    public function messages()
+    public function messages(): array
     {
         return $this->hasMethod('getValidationMessages')
             ? $this->resolveAndCallMethod('getValidationMessages')
             : [];
     }
 
-    public function attributes()
+    public function attributes(): array
     {
         return $this->hasMethod('getValidationAttributes')
             ? $this->resolveAndCallMethod('getValidationAttributes')
@@ -122,7 +122,7 @@ class ActionRequest extends FormRequest
             : $url->previous();
     }
 
-    protected function getErrorBag(Validator $validator)
+    protected function getErrorBag(Validator $validator): string
     {
         return $this->hasMethod('getValidationErrorBag')
             ? $this->resolveAndCallMethod('getValidationErrorBag', compact('validator'))
@@ -157,7 +157,7 @@ class ActionRequest extends FormRequest
         $response->authorize();
     }
 
-    public function validated()
+    public function validated(): array
     {
         return $this->validator->validated();
     }

--- a/src/ActionRequest.php
+++ b/src/ActionRequest.php
@@ -2,17 +2,12 @@
 
 namespace Lorisleiva\Actions;
 
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Auth\Access\Response;
-use Illuminate\Contracts\Validation\Factory as ValidationFactory;
-use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\ValidationException;
-use Lorisleiva\Actions\Concerns\DecorateActions;
+use Lorisleiva\Actions\Concerns\ValidateActions;
 
 class ActionRequest extends FormRequest
 {
-    use DecorateActions;
+    use ValidateActions;
 
     public function validateResolved()
     {
@@ -21,151 +16,7 @@ class ActionRequest extends FormRequest
 
     public function resolve()
     {
-        $this->prepareForValidation();
-        $response = $this->inspectAuthorization();
-
-        if (! $response->allowed()) {
-            $this->deniedAuthorization($response);
-        }
-
-        $instance = $this->getValidatorInstance();
-
-        if ($instance->fails()) {
-            $this->failedValidation($instance);
-        }
-    }
-
-    protected function getValidatorInstance(): Validator
-    {
-        if ($this->validator) {
-            return $this->validator;
-        }
-
-        $factory = $this->container->make(ValidationFactory::class);
-
-        if ($this->hasMethod('getValidator')) {
-            $validator = $this->resolveAndCallMethod('getValidator', compact('factory'));
-        } else {
-            $validator = $this->createDefaultValidator($factory);
-        }
-
-        if ($this->hasMethod('withValidator')) {
-            $this->resolveAndCallMethod('withValidator', compact('validator'));
-        }
-
-        if ($this->hasMethod('afterValidator')) {
-            $validator->after(function ($validator) {
-                $this->resolveAndCallMethod('afterValidator', compact('validator'));
-            });
-        }
-
-        $this->setValidator($validator);
-
-        return $this->validator;
-    }
-
-    protected function createDefaultValidator(ValidationFactory $factory): Validator
-    {
-        return $factory->make(
-            $this->validationData(),
-            $this->rules(),
-            $this->messages(),
-            $this->attributes()
-        );
-    }
-
-    public function validationData(): array
-    {
-        return $this->hasMethod('getValidationData')
-            ? $this->resolveAndCallMethod('getValidationData')
-            : $this->all();
-    }
-
-    public function rules(): array
-    {
-        return $this->hasMethod('rules')
-            ? $this->resolveAndCallMethod('rules')
-            : [];
-    }
-
-    public function messages(): array
-    {
-        return $this->hasMethod('getValidationMessages')
-            ? $this->resolveAndCallMethod('getValidationMessages')
-            : [];
-    }
-
-    public function attributes(): array
-    {
-        return $this->hasMethod('getValidationAttributes')
-            ? $this->resolveAndCallMethod('getValidationAttributes')
-            : [];
-    }
-
-    protected function failedValidation(Validator $validator)
-    {
-        if ($this->hasMethod('getValidationFailure')) {
-            return $this->resolveAndCallMethod('getValidationFailure', compact('validator'));
-        }
-
-        throw (new ValidationException($validator))
-            ->errorBag($this->getErrorBag($validator))
-            ->redirectTo($this->getRedirectUrl());
-    }
-
-    protected function getRedirectUrl()
-    {
-        $url = $this->redirector->getUrlGenerator();
-
-        return $this->hasMethod('getValidationRedirect')
-            ? $this->resolveAndCallMethod('getValidationRedirect', compact('url'))
-            : $url->previous();
-    }
-
-    protected function getErrorBag(Validator $validator): string
-    {
-        return $this->hasMethod('getValidationErrorBag')
-            ? $this->resolveAndCallMethod('getValidationErrorBag', compact('validator'))
-            : 'default';
-    }
-
-    protected function inspectAuthorization(): Response
-    {
-        try {
-            $response = $this->hasMethod('authorize')
-                ? $this->resolveAndCallMethod('authorize')
-                : true;
-        } catch (AuthorizationException $e) {
-            return $e->toResponse();
-        }
-
-        if ($response instanceof Response) {
-            return $response;
-        }
-
-        return $response ? Response::allow() : Response::deny();
-    }
-
-    protected function deniedAuthorization(Response $response): void
-    {
-        if ($this->hasMethod('getAuthorizationFailure')) {
-            $this->resolveAndCallMethod('getAuthorizationFailure', compact('response'));
-
-            return;
-        }
-
-        $response->authorize();
-    }
-
-    public function validated(): array
-    {
-        return $this->validator->validated();
-    }
-
-    protected function prepareForValidation()
-    {
-        if ($this->hasMethod('prepareForValidation')) {
-            return $this->resolveAndCallMethod('prepareForValidation');
-        }
+        $this->setDefaultValidationData($this->all());
+        $this->validate();
     }
 }

--- a/src/ActionValidator.php
+++ b/src/ActionValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lorisleiva\Actions;
+
+use Illuminate\Container\Container;
+use Illuminate\Routing\Redirector;
+use Lorisleiva\Actions\Concerns\ValidateActions;
+
+class ActionValidator
+{
+    use ValidateActions;
+
+    public function __construct($action)
+    {
+        $this->setAction($action);
+        $this->setContainer(Container::getInstance());
+        $this->redirector = $this->container->make(Redirector::class);
+    }
+}

--- a/src/AttributeValidator.php
+++ b/src/AttributeValidator.php
@@ -6,7 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Routing\Redirector;
 use Lorisleiva\Actions\Concerns\ValidateActions;
 
-class ActionValidator
+class AttributeValidator
 {
     use ValidateActions;
 
@@ -15,5 +15,15 @@ class ActionValidator
         $this->setAction($action);
         $this->setContainer(Container::getInstance());
         $this->redirector = $this->container->make(Redirector::class);
+    }
+
+    public static function for($action): self
+    {
+        return new static($action);
+    }
+
+    public function getDefaultValidationData(): array
+    {
+        return $this->fromActionMethod('all');
     }
 }

--- a/src/Concerns/DecorateActions.php
+++ b/src/Concerns/DecorateActions.php
@@ -12,21 +12,21 @@ trait DecorateActions
     /** @var mixed */
     protected $action;
 
-    public function setContainer($container)
+    public function setContainer($container): self
     {
         $this->container = $container;
 
         return $this;
     }
 
-    public function setAction($action)
+    public function setAction($action): self
     {
         $this->action = $action;
 
         return $this;
     }
 
-    protected function hasProperty($property)
+    protected function hasProperty($property): bool
     {
         return property_exists($this->action, $property);
     }
@@ -36,7 +36,7 @@ trait DecorateActions
         return $this->action->{$property};
     }
 
-    protected function hasMethod($method)
+    protected function hasMethod($method): bool
     {
         return method_exists($this->action, $method);
     }

--- a/src/Concerns/DecorateActions.php
+++ b/src/Concerns/DecorateActions.php
@@ -26,27 +26,32 @@ trait DecorateActions
         return $this;
     }
 
-    protected function hasProperty($property): bool
+    protected function hasTrait(string $trait): bool
+    {
+        return in_array($trait, class_uses_recursive($this->action));
+    }
+
+    protected function hasProperty(string $property): bool
     {
         return property_exists($this->action, $property);
     }
 
-    protected function getProperty($property)
+    protected function getProperty(string $property)
     {
         return $this->action->{$property};
     }
 
-    protected function hasMethod($method): bool
+    protected function hasMethod(string $method): bool
     {
         return method_exists($this->action, $method);
     }
 
-    protected function callMethod($method, $parameters = [])
+    protected function callMethod(string $method, array $parameters = [])
     {
         return call_user_func_array([$this->action, $method], $parameters);
     }
 
-    protected function resolveAndCallMethod($method, $extraArguments = [])
+    protected function resolveAndCallMethod(string $method, array $extraArguments = [])
     {
         return $this->container->call([$this->action, $method], $extraArguments);
     }

--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Lorisleiva\Actions\Concerns;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Routing\Redirector;
+use Illuminate\Validation\ValidationException;
+
+trait ValidateActions
+{
+    use DecorateActions;
+
+    /** @var Validator|null */
+    protected $validator = null;
+
+    /** @var Redirector|null */
+    protected $redirector = null;
+
+    /** @var array */
+    protected array $defaultValidationData = [];
+
+    public function setDefaultValidationData(array $defaultValidationData): self
+    {
+        $this->defaultValidationData = $defaultValidationData;
+
+        return $this;
+    }
+
+    public function validate()
+    {
+        $this->prepareForValidation();
+        $response = $this->inspectAuthorization();
+
+        if (! $response->allowed()) {
+            $this->deniedAuthorization($response);
+        }
+
+        $instance = $this->getValidatorInstance();
+
+        if ($instance->fails()) {
+            $this->failedValidation($instance);
+        }
+    }
+
+    protected function getValidatorInstance(): Validator
+    {
+        if ($this->validator) {
+            return $this->validator;
+        }
+
+        $factory = $this->container->make(ValidationFactory::class);
+
+        if ($this->hasMethod('getValidator')) {
+            $validator = $this->resolveAndCallMethod('getValidator', compact('factory'));
+        } else {
+            $validator = $this->createDefaultValidator($factory);
+        }
+
+        if ($this->hasMethod('withValidator')) {
+            $this->resolveAndCallMethod('withValidator', compact('validator'));
+        }
+
+        if ($this->hasMethod('afterValidator')) {
+            $validator->after(function ($validator) {
+                $this->resolveAndCallMethod('afterValidator', compact('validator'));
+            });
+        }
+
+        return $this->validator = $validator;
+    }
+
+    protected function createDefaultValidator(ValidationFactory $factory): Validator
+    {
+        return $factory->make(
+            $this->validationData(),
+            $this->rules(),
+            $this->messages(),
+            $this->attributes()
+        );
+    }
+
+    public function validationData(): array
+    {
+        return $this->hasMethod('getValidationData')
+            ? $this->resolveAndCallMethod('getValidationData')
+            : $this->defaultValidationData;
+    }
+
+    public function rules(): array
+    {
+        return $this->hasMethod('rules')
+            ? $this->resolveAndCallMethod('rules')
+            : [];
+    }
+
+    public function messages(): array
+    {
+        return $this->hasMethod('getValidationMessages')
+            ? $this->resolveAndCallMethod('getValidationMessages')
+            : [];
+    }
+
+    public function attributes(): array
+    {
+        return $this->hasMethod('getValidationAttributes')
+            ? $this->resolveAndCallMethod('getValidationAttributes')
+            : [];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        if ($this->hasMethod('getValidationFailure')) {
+            return $this->resolveAndCallMethod('getValidationFailure', compact('validator'));
+        }
+
+        throw (new ValidationException($validator))
+            ->errorBag($this->getErrorBag($validator))
+            ->redirectTo($this->getRedirectUrl());
+    }
+
+    protected function getRedirectUrl()
+    {
+        $url = $this->redirector->getUrlGenerator();
+
+        return $this->hasMethod('getValidationRedirect')
+            ? $this->resolveAndCallMethod('getValidationRedirect', compact('url'))
+            : $url->previous();
+    }
+
+    protected function getErrorBag(Validator $validator): string
+    {
+        return $this->hasMethod('getValidationErrorBag')
+            ? $this->resolveAndCallMethod('getValidationErrorBag', compact('validator'))
+            : 'default';
+    }
+
+    protected function inspectAuthorization(): Response
+    {
+        try {
+            $response = $this->hasMethod('authorize')
+                ? $this->resolveAndCallMethod('authorize')
+                : true;
+        } catch (AuthorizationException $e) {
+            return $e->toResponse();
+        }
+
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+        return $response ? Response::allow() : Response::deny();
+    }
+
+    protected function deniedAuthorization(Response $response): void
+    {
+        if ($this->hasMethod('getAuthorizationFailure')) {
+            $this->resolveAndCallMethod('getAuthorizationFailure', compact('response'));
+
+            return;
+        }
+
+        $response->authorize();
+    }
+
+    public function validated(): array
+    {
+        return $this->validator->validated();
+    }
+
+    protected function prepareForValidation()
+    {
+        if ($this->hasMethod('prepareForValidation')) {
+            return $this->resolveAndCallMethod('prepareForValidation');
+        }
+    }
+}

--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -2,7 +2,6 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
-use Closure;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;

--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -2,6 +2,7 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+use Closure;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
@@ -18,16 +19,6 @@ trait ValidateActions
 
     /** @var Redirector|null */
     protected $redirector = null;
-
-    /** @var array */
-    protected array $defaultValidationData = [];
-
-    public function setDefaultValidationData(array $defaultValidationData): self
-    {
-        $this->defaultValidationData = $defaultValidationData;
-
-        return $this;
-    }
 
     public function validate()
     {
@@ -86,7 +77,7 @@ trait ValidateActions
     {
         return $this->hasMethod('getValidationData')
             ? $this->resolveAndCallMethod('getValidationData')
-            : $this->defaultValidationData;
+            : $this->getDefaultValidationData();
     }
 
     public function rules(): array

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -3,7 +3,7 @@
 namespace Lorisleiva\Actions\Concerns;
 
 use Illuminate\Support\Arr;
-use Lorisleiva\Actions\ActionValidator;
+use Lorisleiva\Actions\AttributeValidator;
 
 trait WithAttributes
 {
@@ -85,8 +85,7 @@ trait WithAttributes
 
     public function validateAttributes(): array
     {
-        $validator = new ActionValidator($this);
-        $validator->setDefaultValidationData($this->all());
+        $validator = AttributeValidator::for($this);
         $validator->validate();
 
         return $validator->validated();

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -3,7 +3,6 @@
 namespace Lorisleiva\Actions\Concerns;
 
 use Illuminate\Support\Arr;
-use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\ActionValidator;
 
 trait WithAttributes

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -3,6 +3,8 @@
 namespace Lorisleiva\Actions\Concerns;
 
 use Illuminate\Support\Arr;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\ActionValidator;
 
 trait WithAttributes
 {
@@ -80,5 +82,14 @@ trait WithAttributes
     public function __isset($key): bool
     {
         return ! is_null($this->get($key));
+    }
+
+    public function validateAttributes(): array
+    {
+        $validator = new ActionValidator($this);
+        $validator->setDefaultValidationData($this->all());
+        $validator->validate();
+
+        return $validator->validated();
     }
 }

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Lorisleiva\Actions\AttributeValidator;
 
@@ -27,6 +28,23 @@ trait WithAttributes
     public function fill(array $attributes): self
     {
         $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * @param Request $request
+     * @return static
+     */
+    public function fillFromRequest(Request $request): self
+    {
+        $route = $request->route();
+
+        $this->attributes = array_merge(
+            $this->attributes,
+            $route ? $route->parametersWithoutNulls() : [],
+            $request->all(),
+        );
 
         return $this;
     }

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Lorisleiva\Actions\Concerns;
+
+trait WithAttributes
+{
+    protected array $attributes = [];
+
+    /**
+     * @param array $attributes
+     * @return static
+     */
+    public function setRawAttributes(array $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * @param array $attributes
+     * @return static
+     */
+    public function fill(array $attributes): self
+    {
+        $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }
+
+    public function all(): array
+    {
+        return $this->attributes;
+    }
+
+    public function only($keys)
+    {
+        return Arr::only($this->attributes, is_array($keys) ? $keys : func_get_args());
+    }
+
+    public function except($keys)
+    {
+        return Arr::except($this->attributes, is_array($keys) ? $keys : func_get_args());
+    }
+
+    public function has($key)
+    {
+        return Arr::has($this->attributes, $key);
+    }
+
+    public function get($key, $default = null)
+    {
+        return Arr::get($this->attributes, $key, $default);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @return static
+     */
+    public function set(string $key, $value): self
+    {
+        Arr::set($this->attributes, $key, $value);
+
+        return $this;
+    }
+
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
+
+    public function __set($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    public function __isset($key): bool
+    {
+        return ! is_null($this->get($key));
+    }
+}

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -2,6 +2,8 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+use Illuminate\Support\Arr;
+
 trait WithAttributes
 {
     protected array $attributes = [];
@@ -33,17 +35,17 @@ trait WithAttributes
         return $this->attributes;
     }
 
-    public function only($keys)
+    public function only($keys): array
     {
         return Arr::only($this->attributes, is_array($keys) ? $keys : func_get_args());
     }
 
-    public function except($keys)
+    public function except($keys): array
     {
         return Arr::except($this->attributes, is_array($keys) ? $keys : func_get_args());
     }
 
-    public function has($key)
+    public function has($key): bool
     {
         return Arr::has($this->attributes, $key);
     }

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -61,8 +61,8 @@ class ControllerDecorator
         $this->refreshAction();
         $request = $this->refreshRequest();
 
-        if ($this->shouldValidate()) {
-            $request->resolve();
+        if ($this->shouldValidateRequest()) {
+            $request->validate();
         }
 
         $response = $this->run();
@@ -135,7 +135,7 @@ class ControllerDecorator
         }
     }
 
-    protected function shouldValidate(): bool
+    protected function shouldValidateRequest(): bool
     {
         return $this->hasAnyValidationMethod()
             && ! $this->hasTrait(WithAttributes::class);

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -134,7 +134,7 @@ class ControllerDecorator
         }
     }
 
-    protected function shouldValidate()
+    protected function shouldValidate(): bool
     {
         return $this->hasMethod('authorize')
             || $this->hasMethod('rules')

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\RouteDependencyResolverTrait;
 use Illuminate\Support\Str;
 use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\DecorateActions;
+use Lorisleiva\Actions\Concerns\WithAttributes;
 
 class ControllerDecorator
 {
@@ -135,6 +136,12 @@ class ControllerDecorator
     }
 
     protected function shouldValidate(): bool
+    {
+        return $this->hasAnyValidationMethod()
+            && ! $this->hasTrait(WithAttributes::class);
+    }
+
+    protected function hasAnyValidationMethod(): bool
     {
         return $this->hasMethod('authorize')
             || $this->hasMethod('rules')

--- a/tests/AsActionWithValidatedAttributesTest.php
+++ b/tests/AsActionWithValidatedAttributesTest.php
@@ -2,7 +2,6 @@
 
 namespace Lorisleiva\Actions\Tests;
 
-use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;

--- a/tests/AsActionWithValidatedAttributesTest.php
+++ b/tests/AsActionWithValidatedAttributesTest.php
@@ -2,9 +2,12 @@
 
 namespace Lorisleiva\Actions\Tests;
 
+use Closure;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Validation\ValidationException;
 use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Lorisleiva\Actions\Concerns\WithAttributes;
@@ -108,6 +111,26 @@ it('runs as an object', function () {
     expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
 });
 
+it('fails authorization as an object', function () {
+    // Given we pass an unauthorized operation.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we expect an authorizaion exception.
+})->expectException(AuthorizationException::class);
+
+it('fails validation as an object', function () {
+    // Given we pass invalid data.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);
+
 it('runs as a controller', function () {
     // Given we have a route registered for that action.
     Route::post('compute/{operation}', AsActionWithValidatedAttributesTest::class);
@@ -124,6 +147,31 @@ it('runs as a controller', function () {
     expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
 });
 
+it('fails authorization as a controller', function () {
+    // Given we have a route registered for that action.
+    Route::post('compute/{operation}', AsActionWithValidatedAttributesTest::class);
+
+    // When we run that endpoint with an unauthorized operation.
+    $response = $this->postJson('compute/unauthorized');
+
+    // Then we expect a forbidden response.
+    $response->assertForbidden();
+    $response->assertExactJson([
+        'message' => 'This action is unauthorized.',
+    ]);
+});
+
+it('fails validation as a controller', function () {
+    // Given we pass invalid data.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);
+
 it('runs as a job', function () {
     // When we dispatch the action as a job.
     AsActionWithValidatedAttributesTest::dispatch(6, 'multiplication', 7);
@@ -131,6 +179,26 @@ it('runs as a job', function () {
     // Then we get the expected result.
     expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
 });
+
+it('fails authorization as a job', function () {
+    // Given we pass an unauthorized operation.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we expect an authorizaion exception.
+})->expectException(AuthorizationException::class);
+
+it('fails validation as a job', function () {
+    // Given we pass invalid data.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);
 
 it('runs as a listener', function () {
     // Given we are listening for the OperationRequestedEvent.
@@ -143,6 +211,26 @@ it('runs as a listener', function () {
     expect($results[0])->toBe(42);
     expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
 });
+
+it('fails authorization as a listener', function () {
+    // Given we pass an unauthorized operation.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we expect an authorizaion exception.
+})->expectException(AuthorizationException::class);
+
+it('fails validation as a listener', function () {
+    // Given we pass invalid data.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);
 
 it('runs as a command', function () {
     // Given we registered the action as a command.
@@ -158,6 +246,26 @@ it('runs as a command', function () {
     $command->run();
     expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
 });
+
+it('fails authorization as a command', function () {
+    // Given we pass an unauthorized operation.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we expect an authorizaion exception.
+})->expectException(AuthorizationException::class);
+
+it('fails validation as a command', function () {
+    // Given we pass invalid data.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);
 
 it('runs as a mock', function () {
     // Given the following attributes.
@@ -178,3 +286,23 @@ it('runs as a mock', function () {
     // Then we get the expected result.
     expect($result)->toBe(42);
 });
+
+it('fails authorization as a mock', function () {
+    // Given we pass an unauthorized operation.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we expect an authorizaion exception.
+})->expectException(AuthorizationException::class);
+
+it('fails validation as a mock', function () {
+    // Given we pass invalid data.
+    AsActionWithValidatedAttributesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);

--- a/tests/AsActionWithValidatedAttributesTest.php
+++ b/tests/AsActionWithValidatedAttributesTest.php
@@ -2,7 +2,6 @@
 
 namespace Lorisleiva\Actions\Tests;
 
-use Closure;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;

--- a/tests/AsActionWithValidatedAttributesTest.php
+++ b/tests/AsActionWithValidatedAttributesTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\WithAttributes;
+use Lorisleiva\Actions\Tests\Stubs\OperationRequestedEvent;
+
+class AsActionWithValidatedAttributesTest
+{
+    use AsAction;
+    use WithAttributes;
+
+    public string $commandSignature = 'my:command {operation} {left} {right}';
+
+    public static ?int $latestResult;
+
+    public function authorize(): bool
+    {
+        return $this->operation !== 'unauthorized';
+    }
+
+    public function rules(): array
+    {
+        return [
+            'operation' => ['in:addition,substraction,multiplication'],
+            'left' => ['required', 'integer'],
+            'right' => ['required', 'integer'],
+        ];
+    }
+
+    public function handle(array $attributes = []): int
+    {
+        $this->fill($attributes)->validateAttributes();
+
+        return static::$latestResult = $this->applyStrategyFromOperation();
+    }
+
+    protected function applyStrategyFromOperation(): int
+    {
+        switch ($this->operation) {
+            case 'substraction':
+                return $this->left - $this->right;
+            case 'multiplication':
+                return $this->left * $this->right;
+            case 'addition':
+            default:
+                return $this->left + $this->right;
+        }
+    }
+
+    public function asController(ActionRequest $request): array
+    {
+        $this->fill([
+            'operation' => $request->route('operation'),
+            'left' => (int) $request->get('left'),
+            'right' => (int) $request->get('right'),
+        ]);
+
+        return ['result' => $this->handle()];
+    }
+
+    public function asJob(int $left, string $operation, int $right): int
+    {
+        return $this->handle(compact('operation', 'left', 'right'));
+    }
+
+    public function asListener(OperationRequestedEvent $event): int
+    {
+        return $this->handle([
+            'operation' => $event->operation,
+            'left' => $event->left,
+            'right' => $event->right,
+        ]);
+    }
+
+    public function asCommand(Command $command): void
+    {
+        $result = $this->handle([
+            'operation' => $command->argument('operation'),
+            'left' => $command->argument('left'),
+            'right' => $command->argument('right'),
+        ]);
+
+        $command->line('Result: ' . $result);
+    }
+}
+
+beforeEach(function () {
+    // Given we reset the latest result between tests.
+    AsActionWithValidatedAttributesTest::$latestResult = null;
+});
+
+it('runs as an object', function () {
+    // When we run the action as a plain object.
+    $result = AsActionWithValidatedAttributesTest::run([
+        'operation' => 'addition',
+        'left' => 40,
+        'right' => 2,
+    ]);
+
+    // Then we get the expected result.
+    expect($result)->toBe(42);
+    expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
+});
+
+it('runs as a controller', function () {
+    // Given we have a route registered for that action.
+    Route::post('compute/{operation}', AsActionWithValidatedAttributesTest::class);
+
+    // When we run the action as an endpoint.
+    $response = $this->postJson('compute/substraction', [
+        'left' => 100,
+        'right' => 58,
+    ]);
+
+    // Then we get the expected result.
+    $response->assertOk();
+    $response->assertExactJson(['result' => 42]);
+    expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
+});
+
+it('runs as a job', function () {
+    // When we dispatch the action as a job.
+    AsActionWithValidatedAttributesTest::dispatch(6, 'multiplication', 7);
+
+    // Then we get the expected result.
+    expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
+});
+
+it('runs as a listener', function () {
+    // Given we are listening for the OperationRequestedEvent.
+    Event::listen(OperationRequestedEvent::class, AsActionWithValidatedAttributesTest::class);
+
+    // When we dispatch the OperationRequestedEvent.
+    $results = Event::dispatch(new OperationRequestedEvent('addition', 21, 21));
+
+    // Then we get the expected result.
+    expect($results[0])->toBe(42);
+    expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
+});
+
+it('runs as a command', function () {
+    // Given we registered the action as a command.
+    registerCommands([AsActionWithValidatedAttributesTest::class]);
+
+    // When we run the action as a command.
+    $command = $this->artisan('my:command multiplication 21 2');
+
+    // Then we get the expected output.
+    $command->expectsOutput('Result: 42');
+
+    // And the expected result.
+    $command->run();
+    expect(AsActionWithValidatedAttributesTest::$latestResult)->toBe(42);
+});
+
+it('runs as a mock', function () {
+    // Given the following attributes.
+    $attributes = [
+        'operation' => 'substraction',
+        'left' => 1,
+        'right' => 2,
+    ];
+
+    // And given we mock the action with some expectations.
+    AsActionWithValidatedAttributesTest::shouldRun()
+        ->with($attributes)
+        ->andReturn(42);
+
+    // When we run the action with the expected arguments.
+    $result = AsActionWithValidatedAttributesTest::run($attributes);
+
+    // Then we get the expected result.
+    expect($result)->toBe(42);
+});

--- a/tests/AsControllerAndObjectTest.php
+++ b/tests/AsControllerAndObjectTest.php
@@ -38,8 +38,8 @@ it('works as a controller', function () {
     Route::post('/add/{left}', AsControllerAndObjectTest::class);
 
     // When we call that route.
-    $reponse = $this->postJson('/add/1', ['right' => 2]);
+    $response = $this->postJson('/add/1', ['right' => 2]);
 
     // Then we receive a successful response.
-    $reponse->assertOk()->assertExactJson(['addition' => 3]);
+    $response->assertOk()->assertExactJson(['addition' => 3]);
 });

--- a/tests/AsControllerTest.php
+++ b/tests/AsControllerTest.php
@@ -38,10 +38,10 @@ it('can be run as a controller', function () {
     Route::get('/calculator/{left}/plus/{right}', AsControllerTest::class);
 
     // When we call that route.
-    $reponse = $this->getJson('/calculator/5/plus/3');
+    $response = $this->getJson('/calculator/5/plus/3');
 
     // Then we receive a successful response.
-    $reponse->assertOk()->assertExactJson(['addition' => 8]);
+    $response->assertOk()->assertExactJson(['addition' => 8]);
 });
 
 it('does not construct the action when registering the route', function () {
@@ -57,12 +57,12 @@ it('constructs the action and runs the handle method exactly once per request', 
     Route::get('/calculator/{left}/plus/{right}', AsControllerTest::class);
 
     // When we call that same route twice.
-    $reponseA = $this->getJson('/calculator/1/plus/2');
-    $reponseB = $this->getJson('/calculator/2/plus/3');
+    $responseA = $this->getJson('/calculator/1/plus/2');
+    $responseB = $this->getJson('/calculator/2/plus/3');
 
     // Then both response were successful
-    $reponseA->assertOk()->assertExactJson(['addition' => 3]);
-    $reponseB->assertOk()->assertExactJson(['addition' => 5]);
+    $responseA->assertOk()->assertExactJson(['addition' => 3]);
+    $responseB->assertOk()->assertExactJson(['addition' => 5]);
 
     // And the action was constructed only once.
     expect(AsControllerTest::$constructed)->toBe(2);

--- a/tests/AsControllerWithAuthorizeAndRulesTest.php
+++ b/tests/AsControllerWithAuthorizeAndRulesTest.php
@@ -39,39 +39,39 @@ beforeEach(function () {
 
 it('passes authorization and validation', function () {
     // When we call that route with the right request.
-    $reponse = $this->postJson('/calculator', [
+    $response = $this->postJson('/calculator', [
         'operation' => 'substraction',
         'left' => 5,
         'right' => 3,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk()->assertExactJson([2]);
+    $response->assertOk()->assertExactJson([2]);
 });
 
 it('fails authorization', function () {
     // When we call that route with an unauthorized request.
-    $reponse = $this->postJson('/calculator', [
+    $response = $this->postJson('/calculator', [
         'operation' => 'unauthorized',
     ]);
 
     // Then we receive a forbidden error.
-    $reponse->assertForbidden();
-    $reponse->assertExactJson([
+    $response->assertForbidden();
+    $response->assertExactJson([
         'message' => 'This action is unauthorized.',
     ]);
 });
 
 it('fails validation', function () {
     // When we call that route with an invalid request.
-    $reponse = $this->postJson('/calculator', [
+    $response = $this->postJson('/calculator', [
         'operation' => 'multiplication',
         'left' => 'five',
     ]);
 
     // Then we receive a validation error.
-    $reponse->assertStatus(422);
-    $reponse->assertJsonValidationErrors([
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors([
         'operation' => 'The selected operation is invalid.',
         'left' => 'The left must be an integer.',
         'right' => 'The right field is required.',

--- a/tests/AsControllerWithCustomFailuresTest.php
+++ b/tests/AsControllerWithCustomFailuresTest.php
@@ -46,36 +46,36 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide valid data.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'left' => 1,
         'right' => 2,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk();
-    $reponse->assertExactJson([3]);
+    $response->assertOk();
+    $response->assertExactJson([3]);
 });
 
 it('fails authorization with a custom failure', function () {
     // When we make an unauthorized request.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'operation' => 'unauthorized',
     ]);
 
     // Then we receive a custom authorization error.
-    $reponse->assertStatus(400);
-    $reponse->assertExactJson([
+    $response->assertStatus(400);
+    $response->assertExactJson([
         'message' => 'Custom authorization failure.',
     ]);
 });
 
 it('fails validation with a custom failure', function () {
     // When we provide invalid data.
-    $reponse = $this->postJson('/controller');
+    $response = $this->postJson('/controller');
 
     // Then we receive a custom validation error.
-    $reponse->assertStatus(400);
-    $reponse->assertExactJson([
+    $response->assertStatus(400);
+    $response->assertExactJson([
         'message' => 'Custom validation failure.',
     ]);
 });

--- a/tests/AsControllerWithCustomRedirectAndErrorBagTest.php
+++ b/tests/AsControllerWithCustomRedirectAndErrorBagTest.php
@@ -44,14 +44,14 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide valid data.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'left' => 1,
         'right' => 2,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk();
-    $reponse->assertExactJson([3]);
+    $response->assertOk();
+    $response->assertExactJson([3]);
 });
 
 it('throws a validation exception with the custom redirect url and error bag', function () {

--- a/tests/AsControllerWithCustomValidationDataTest.php
+++ b/tests/AsControllerWithCustomValidationDataTest.php
@@ -40,23 +40,23 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide valid data.
-    $reponse = $this->postJson('/controller/1', [
+    $response = $this->postJson('/controller/1', [
         'right' => 2,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk();
-    $reponse->assertExactJson([3]);
+    $response->assertOk();
+    $response->assertExactJson([3]);
 });
 
 it('fails validation', function () {
     // When we provide invalid data.
-    $reponse = $this->postJson('/controller/1');
+    $response = $this->postJson('/controller/1');
 
     // Then we receive a validation error.
-    $reponse->assertStatus(422);
-    $reponse->assertJsonMissingValidationErrors('left');
-    $reponse->assertJsonValidationErrors([
+    $response->assertStatus(422);
+    $response->assertJsonMissingValidationErrors('left');
+    $response->assertJsonValidationErrors([
         'right' => 'The right field is required.',
     ]);
 });

--- a/tests/AsControllerWithCustomValidatorTest.php
+++ b/tests/AsControllerWithCustomValidatorTest.php
@@ -40,24 +40,24 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide valid data.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'left' => 1,
         'right' => 2,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk();
-    $reponse->assertExactJson([3]);
+    $response->assertOk();
+    $response->assertExactJson([3]);
 });
 
 it('fails validation', function () {
     // When we provide invalid data.
-    $reponse = $this->postJson('/controller');
+    $response = $this->postJson('/controller');
 
     // Then we receive a validation error with the messages
     // and attributes defined in the custom validator.
-    $reponse->assertStatus(422);
-    $reponse->assertJsonValidationErrors([
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors([
         'left' => 'You forgot the left operand',
         'right' => 'The right operand field is required.',
     ]);

--- a/tests/AsControllerWithMiddlewareTest.php
+++ b/tests/AsControllerWithMiddlewareTest.php
@@ -35,10 +35,10 @@ it('can register controller middleware', function () {
     Route::post('/calculator', AsControllerWithMiddlewareTest::class);
 
     // When we call that route.
-    $reponse = $this->postJson('/calculator', [
+    $response = $this->postJson('/calculator', [
         'operation' => 'middleware',
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk()->assertExactJson(['caught by middleware']);
+    $response->assertOk()->assertExactJson(['caught by middleware']);
 });

--- a/tests/AsControllerWithPolicyResponsesTest.php
+++ b/tests/AsControllerWithPolicyResponsesTest.php
@@ -33,21 +33,21 @@ beforeEach(function () {
 
 it('passes authorization', function () {
     // When we make an authorised request.
-    $reponse = $this->postJson('/controller');
+    $response = $this->postJson('/controller');
 
     // Then we receive a successful response.
-    $reponse->assertOk();
+    $response->assertOk();
 });
 
 it('fails authorization', function () {
     // When we make an unauthorised request.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'operation' => 'unauthorized',
     ]);
 
     // Then we receive a forbidden error with our custom message.
-    $reponse->assertForbidden();
-    $reponse->assertExactJson([
+    $response->assertForbidden();
+    $response->assertExactJson([
         'message' => 'My custom authorization message.',
     ]);
 });

--- a/tests/AsControllerWithPrepareForValidationTest.php
+++ b/tests/AsControllerWithPrepareForValidationTest.php
@@ -45,21 +45,21 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide a raw expression
-    $reponse = $this->getJson('/controller/1+2');
+    $response = $this->getJson('/controller/1+2');
 
     // Then that expression was parsed as attributes
     // by the prepareForValidation method.
-    $reponse->assertOk()->assertExactJson([3]);
+    $response->assertOk()->assertExactJson([3]);
 });
 
 it('fails validation', function () {
     // When we provide a raw expression with the missing right operand.
-    $reponse = $this->getJson('/controller/4-');
+    $response = $this->getJson('/controller/4-');
 
     // Then that expression was parsed with a missing
     // right operand and results in a validation error.
-    $reponse->assertStatus(422);
-    $reponse->assertJsonValidationErrors([
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors([
         'right' => 'The right field is required.',
     ]);
 });

--- a/tests/AsControllerWithRoutesTest.php
+++ b/tests/AsControllerWithRoutesTest.php
@@ -26,8 +26,8 @@ it('can register its routes directly in the action', function () {
     Actions::registerRoutesForAction(AsControllerWithRoutesTest::class);
 
     // When we call the route defined on the action.
-    $reponse = $this->getJson('/controller/with/routes');
+    $response = $this->getJson('/controller/with/routes');
 
     // Then we receive the expected response.
-    $reponse->assertOk()->assertExactJson(['Ok']);
+    $response->assertOk()->assertExactJson(['Ok']);
 });

--- a/tests/AsControllerWithValidatedAttributesTest.php
+++ b/tests/AsControllerWithValidatedAttributesTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsController;
+use Lorisleiva\Actions\Concerns\WithAttributes;
+
+class AsControllerWithValidatedAttributesTest
+{
+    use AsController;
+    use WithAttributes;
+
+    public static bool $reachedHandleMethod = false;
+
+    public function authorize(): bool
+    {
+        return $this->operation !== 'unauthorized';
+    }
+
+    public function rules(): array
+    {
+        return [
+            'operation' => ['in:addition,substraction'],
+            'left' => ['required', 'integer'],
+            'right' => ['required', 'integer'],
+        ];
+    }
+
+    public function handle(ActionRequest $request): array
+    {
+        static::$reachedHandleMethod = true;
+        $this->fillFromRequest($request)->validateAttributes();
+
+        $result = $this->operation === 'addition'
+            ? $this->left + $this->right
+            : $this->left - $this->right;
+
+        return compact('result');
+    }
+}
+
+beforeEach(function () {
+    // Given the action is registered as a controller.
+    Route::post('/calculator', AsControllerWithValidatedAttributesTest::class);
+
+    // And given we reset the static variables between each test.
+    AsControllerWithValidatedAttributesTest::$reachedHandleMethod = true;
+});
+
+it('passes authorization and validation', function () {
+    // When we call that route with valid attributes.
+    $response = $this->postJson('/calculator', [
+        'operation' => 'substraction',
+        'left' => 5,
+        'right' => 3,
+    ]);
+
+    // Then we receive a successful response.
+    $response->assertOk()->assertExactJson(['result' => 2]);
+});
+
+it('fails authorization', function () {
+    // When we call that route with an unauthorized request.
+    $response = $this->postJson('/calculator', [
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we receive a forbidden error.
+    $response->assertForbidden();
+    $response->assertExactJson([
+        'message' => 'This action is unauthorized.',
+    ]);
+});
+
+it('fails validation', function () {
+    // When we call that route with an invalid request.
+    $response = $this->postJson('/calculator', [
+        'operation' => 'multiplication',
+        'left' => 'five',
+    ]);
+
+    // Then we receive a validation error.
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors([
+        'operation' => 'The selected operation is invalid.',
+        'left' => 'The left must be an integer.',
+        'right' => 'The right field is required.',
+    ]);
+});
+
+it('uses a new validator at every request', function () {
+    $this->post('/calculator', ['operation' => 'addition', 'left' => 5])
+        ->assertSessionHasErrors('right')
+        ->assertSessionDoesntHaveErrors(['operation', 'left']);
+
+    $this->post('/calculator', ['operation' => 'addition', 'right' => 5])
+        ->assertSessionHasErrors('left')
+        ->assertSessionDoesntHaveErrors(['operation', 'right']);
+
+    $this->post('/calculator', ['operation' => 'invalid'])
+        ->assertSessionHasErrors(['operation', 'right', 'left']);
+});
+
+it('does not validate from the request when using attributes', function () {
+    // When we call that route with an unauthorized request.
+    $response = $this->postJson('/calculator', [
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we receive a forbidden error.
+    $response->assertForbidden();
+
+    // But we still reached the handle method which would not have
+    // happened if we resolved the ActionRequest validation.
+    expect(AsControllerWithValidatedAttributesTest::$reachedHandleMethod)
+        ->toBeTrue();
+});

--- a/tests/AsControllerWithValidationMessagesTest.php
+++ b/tests/AsControllerWithValidationMessagesTest.php
@@ -45,24 +45,24 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide valid data.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'left' => 1,
         'right' => 2,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk();
-    $reponse->assertExactJson([3]);
+    $response->assertOk();
+    $response->assertExactJson([3]);
 });
 
 
 it('fails validation with custom messages and attributes', function () {
     // When we provide invalid data.
-    $reponse = $this->postJson('/controller');
+    $response = $this->postJson('/controller');
 
     // Then we receive a validation error with these custom messages.
-    $reponse->assertStatus(422);
-    $reponse->assertJsonValidationErrors([
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors([
         'left' => 'You forgot the left operand',
         'right' => 'The right operand field is required.',
     ]);

--- a/tests/AsControllerWithValidatorCallbacksTest.php
+++ b/tests/AsControllerWithValidatorCallbacksTest.php
@@ -40,25 +40,25 @@ beforeEach(function () {
 
 it('passes validation', function () {
     // When we provide valid data.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'left' => 30,
         'right' => 63,
     ]);
 
     // Then we receive a successful response.
-    $reponse->assertOk()->assertExactJson([93]);
+    $response->assertOk()->assertExactJson([93]);
 });
 
 it('fails validation', function () {
     // When we provide invalid data.
-    $reponse = $this->postJson('/controller', [
+    $response = $this->postJson('/controller', [
         'left' => 63,
         'right' => 30,
     ]);
 
     // Then we receive a validation error.
-    $reponse->assertStatus(422);
-    $reponse->assertJsonValidationErrors([
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors([
         'left' => 'Left must be smaller than 42.',
         'right' => 'Right must be odd.',
     ]);

--- a/tests/AsObjectWithAuthorizeAndRulesTest.php
+++ b/tests/AsObjectWithAuthorizeAndRulesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Lorisleiva\Actions\Concerns\AsObject;
+use Lorisleiva\Actions\Concerns\WithAttributes;
+
+class AsObjectWithAuthorizeAndRulesTest
+{
+    use AsObject;
+    use WithAttributes;
+
+    public function authorize(): bool
+    {
+        return $this->operation !== 'unauthorized';
+    }
+
+    public function rules(): array
+    {
+        return [
+            'operation' => ['in:addition,substraction'],
+            'left' => ['required', 'integer'],
+            'right' => ['required', 'integer'],
+        ];
+    }
+
+    public function handle()
+    {
+        return $this->operation === 'addition'
+            ? $this->left + $this->right
+            : $this->left - $this->right;
+    }
+}
+
+it('lab', function () {
+    $object = AsObjectWithAuthorizeAndRulesTest::run();
+
+    dd($object);
+});

--- a/tests/AsObjectWithAuthorizeAndRulesTest.php
+++ b/tests/AsObjectWithAuthorizeAndRulesTest.php
@@ -2,6 +2,8 @@
 
 namespace Lorisleiva\Actions\Tests;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Validation\ValidationException;
 use Lorisleiva\Actions\Concerns\AsObject;
 use Lorisleiva\Actions\Concerns\WithAttributes;
 
@@ -24,16 +26,44 @@ class AsObjectWithAuthorizeAndRulesTest
         ];
     }
 
-    public function handle()
+    public function handle(array $attributes)
     {
+        $this->fill($attributes)->validateAttributes();
+
         return $this->operation === 'addition'
             ? $this->left + $this->right
             : $this->left - $this->right;
     }
 }
 
-it('lab', function () {
-    $object = AsObjectWithAuthorizeAndRulesTest::run();
+it('passes authorization and validation', function () {
+    // When we pass the right arguments.
+    $result = AsObjectWithAuthorizeAndRulesTest::run([
+        'operation' => 'substraction',
+        'left' => 8,
+        'right' => 3,
+    ]);
 
-    dd($object);
+    // Then we receive the expected result.
+    expect($result)->toBe(5);
 });
+
+it('fails authorization', function () {
+    // When we pass an unauthorized operation.
+    AsObjectWithAuthorizeAndRulesTest::run([
+        'operation' => 'unauthorized',
+    ]);
+
+    // Then we expect a authorization exception.
+})->expectException(AuthorizationException::class);
+
+it('fails validation', function () {
+    // When we pass a invalid data.
+    AsObjectWithAuthorizeAndRulesTest::run([
+        'operation' => 'invalid_operation',
+        'left' => 'one',
+        'right' => 'two',
+    ]);
+
+    // Then we expect a validation exception.
+})->expectException(ValidationException::class);

--- a/tests/AsObjectWithValidatedAttributesTest.php
+++ b/tests/AsObjectWithValidatedAttributesTest.php
@@ -7,7 +7,7 @@ use Illuminate\Validation\ValidationException;
 use Lorisleiva\Actions\Concerns\AsObject;
 use Lorisleiva\Actions\Concerns\WithAttributes;
 
-class AsObjectWithAuthorizeAndRulesTest
+class AsObjectWithValidatedAttributesTest
 {
     use AsObject;
     use WithAttributes;
@@ -38,7 +38,7 @@ class AsObjectWithAuthorizeAndRulesTest
 
 it('passes authorization and validation', function () {
     // When we pass the right arguments.
-    $result = AsObjectWithAuthorizeAndRulesTest::run([
+    $result = AsObjectWithValidatedAttributesTest::run([
         'operation' => 'substraction',
         'left' => 8,
         'right' => 3,
@@ -50,7 +50,7 @@ it('passes authorization and validation', function () {
 
 it('fails authorization', function () {
     // When we pass an unauthorized operation.
-    AsObjectWithAuthorizeAndRulesTest::run([
+    AsObjectWithValidatedAttributesTest::run([
         'operation' => 'unauthorized',
     ]);
 
@@ -59,7 +59,7 @@ it('fails authorization', function () {
 
 it('fails validation', function () {
     // When we pass a invalid data.
-    AsObjectWithAuthorizeAndRulesTest::run([
+    AsObjectWithValidatedAttributesTest::run([
         'operation' => 'invalid_operation',
         'left' => 'one',
         'right' => 'two',


### PR DESCRIPTION
## Why?

Since Laravel Actions v2 was released, a common feature request has been to offer **authorization and validation for every pattern** and not just controllers.

In Laravel Actions v1, this was made possible by having unified attributes in the `Action` class. When building v2, I decided to make Actions as less intrusive as possible allowing any class to be executed as a controller, job, etc. This meant dropping the unified attributes and providing a simpler, more intuitive API using `asController`, `asJob`, etc. methods.

Whilst I still believe this was the right way to go, I can also understand the value of having a set of unified attributes that can be validated and accessed from anywhere. This is why I decided to provide a new optional `WithAttributes` trait.

## What?

This PR provides a new `WithAttributes` trait which is not included in the `AsAction` trait by default.

```php
class MyAction
{
    use AsAction;
    use WithAttributes;

    // ...
}
```

Very similarly to Laravel Actions v1, it provides the following methods to access and update attributes:

```php
$action->setRawAttributes(['key' => 'value']); // Replace all attributes.
$action->fill(['key' => 'value']);             // Merge the given attributes with the existing attributes.
$action->fillFromRequest($request);            // Merge the request data and route parameters with the existing attributes.
$action->all();                                // Retrieve all attributes.
$action->only('title', 'body');                // Retrieve only the attributes provided.
$action->except('body');                       // Retrieve all attributes excepts the one provided.
$action->has('title');                         // Whether the action has the provided attribute.
$action->get('title');                         // Get an attribute.
$action->get('title', 'Untitled');             // Get an attribute with default value.
$action->set('title', 'My blog post');         // Set an attribute.
$action->title;                                // Get an attribute.
$action->title = 'My blog post';               // Set an attribute.
```

Additionally, it provides a new `validateAttributes()` method that you can use at any time to trigger the authorization and validation of your attributes. This method returns the validated data if you need it.

```php
public function handle(array $attributes = [])
{
    $this->fill($attributes);
    $this->validateAttributes();

    // ...
}
```

When calling the `validateAttributes()` method, the following methods will be used from the action allowing you to customise the authorization and validation logic directly in the action. Note that these are the same methods used to validate actions as controller right now.

- [`prepareForValidation`](https://laravelactions.com/2.x/as-controller.html#prepareforvalidation)
- [`authorize`](https://laravelactions.com/2.x/as-controller.html#authorize)
- [`rules`](https://laravelactions.com/2.x/as-controller.html#rules)
- [`withValidator`](https://laravelactions.com/2.x/as-controller.html#withvalidator)
- [`afterValidator`](https://laravelactions.com/2.x/as-controller.html#aftervalidator)
- [`getValidator`](https://laravelactions.com/2.x/as-controller.html#getvalidator)
- [`getValidationData`](https://laravelactions.com/2.x/as-controller.html#getvalidationdata)
- [`getValidationMessages`](https://laravelactions.com/2.x/as-controller.html#getvalidationmessages)
- [`getValidationAttributes`](https://laravelactions.com/2.x/as-controller.html#getvalidationattributes)
- [`getValidationRedirect`](https://laravelactions.com/2.x/as-controller.html#getvalidationredirect)
- [`getValidationErrorBag`](https://laravelactions.com/2.x/as-controller.html#getvalidationerrorbag)
- [`getValidationFailure`](https://laravelactions.com/2.x/as-controller.html#getvalidationfailure)
- [`getAuthorizationFailure`](https://laravelactions.com/2.x/as-controller.html#getauthorizationfailure)

When using the `WithAttributes` trait, the action will no longer automatically validate the `ActionRequest` for you. This is to avoid triggering the validation process twice: once on the `ActionRequest` form request and once on your attributes. If you want to manually trigger validation on the `ActionRequest` instance, you can do so by calling the `validate()` method on the instance.

```php
public function asController(ActionRequest $request)
{
    $request->validate();

    // ...
}
```

This will use the same methods listed above to customise the authorization and validation logic.

## How?

- Add a new `WithAttributes` trait with all the methods mentioned above.
- Add a new `ValidateActions` trait that contains all the shared code around using actions to configure the authorization and validation process.
- Add a new `AttributeValidator` that uses that trait and provides default validation data using `$action->all()`.
- Update the `ActionRequest` to use the new `ValidationActions` trait and provide default validation data using `$request->all()`.
- Update the `shouldValidateRequest` method on the `ControllerDecorator` such that it returns `false` if the action uses the trait `WithAttributes`.
- Add lots of tests.