### PR TITLE
Refactoring stub variables to match Laravel's pattern

### DIFF
--- a/src/Console/stubs/action.stub
+++ b/src/Console/stubs/action.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Lorisleiva\Actions\Concerns\AsAction;
 
-class DummyClass
+class {{ class }}
 {
     use AsAction;
 


### PR DESCRIPTION
Compare https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/stubs/test.stub. The generation still works, I didn't find a test for it.
Related to #116.