### PR TITLE
Allow for matching tests to be created on make:action

### DIFF
--- a/src/Console/MakeActionCommand.php
+++ b/src/Console/MakeActionCommand.php
@@ -2,10 +2,13 @@
 
 namespace Lorisleiva\Actions\Console;
 
+use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 
 class MakeActionCommand extends GeneratorCommand
 {
+    use CreatesMatchingTest;
+
     protected $name = 'make:action';
 
     protected $description = 'Create a new Action';


### PR DESCRIPTION
Add `Illuminate\Console\Concerns\CreatesMatchingTest` to `Lorisleiva\Actions\Console\MakeActionCommand` to match framework generator command patterns. 

Closes #153 