### PR TITLE
Support for new function jobFailed(Throwable $e)

### DIFF
--- a/src/Decorators/JobDecorator.php
+++ b/src/Decorators/JobDecorator.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Reflector;
 use Lorisleiva\Actions\Concerns\DecorateActions;
 use ReflectionMethod;
 use ReflectionParameter;
+use Throwable;
 
 class JobDecorator implements ShouldQueue
 {
@@ -136,7 +137,21 @@ class JobDecorator implements ShouldQueue
         return $this->fromActionMethod('getJobMiddleware', $this->parameters, []);
     }
 
-    public function displayName(): string
+	/**
+	 * Laravel will call failed() on a job that fails. This function will call
+	 * the function jobFailed(Throwable $e) on the underlying action if Laravel
+	 * calls the failed() function on the job.
+	 *
+	 * @param Throwable $e
+	 * @return void
+	 */
+	public function failed(Throwable $e) {
+		if ($this->hasMethod('jobFailed')) {
+			$this->callMethod('jobFailed', [$e]);
+		}
+	}
+
+	public function displayName(): string
     {
         return $this->fromActionMethod(
             'getJobDisplayName',

--- a/tests/AsJobWithFailureTest.php
+++ b/tests/AsJobWithFailureTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Exception;
+use Lorisleiva\Actions\Concerns\AsJob;
+use Throwable;
+
+class AsJobWithFailureTest
+{
+    use AsJob;
+
+	/** @var null|int|string */
+	public static $latestResult;
+
+    public function handle(bool $throwException)
+    {
+		static::$latestResult = 'started';
+
+		if ($throwException) {
+			throw new Exception();
+		}
+
+		static::$latestResult = 'completed';
+
+	}
+
+	public function jobFailed(Throwable $e) {
+		static::$latestResult = 'exception_thrown';
+	}
+}
+
+it('asserts a job failure calls the jobFailed() function', function () {
+
+	$this->expectException(Exception::class);
+
+	// When we dispatch the action.
+	AsJobWithFailureTest::dispatch(true);
+
+	expect(AsJobWithFailureTest::$latestResult)->toBe('exception_thrown');
+
+});
+
+it('asserts no job failure does not call the jobFailed() function', function () {
+
+	// When we dispatch the action.
+	AsJobWithFailureTest::dispatch(false);
+
+	expect(AsJobWithFailureTest::$latestResult)->toBe('completed');
+
+});
+


### PR DESCRIPTION
When a Laravel job fails, Laravel supports cleaning up from that job by defining a `failed()` function on the job class.

See Laravel documentation here: https://laravel.com/docs/8.x/queues#cleaning-up-after-failed-jobs

This PR adds support for a new function on the Laravel Action called `jobFailed(Throwable $e)`. If a job fails, this function will be called to provide an opportunity to clean up from the job failure.

See #161.

I don't have much experience writing tests, and would appreciate any feedback on writing a better test if needed.