### PR TITLE
Conditional Object runs added

### DIFF
--- a/src/Concerns/AsObject.php
+++ b/src/Concerns/AsObject.php
@@ -2,6 +2,8 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+use Illuminate\Support\Fluent;
+
 trait AsObject
 {
     /**
@@ -20,5 +22,25 @@ trait AsObject
     public static function run(...$arguments)
     {
         return static::make()->handle(...$arguments);
+    }
+
+    /**
+     * @param $boolean
+     * @param ...$arguments
+     * @return mixed|\Illuminate\Support\Fluent
+     */
+    public static function runIf($boolean, ...$arguments)
+    {
+        return $boolean ? static::run(...$arguments) : new Fluent;
+    }
+
+    /**
+     * @param $boolean
+     * @param ...$arguments
+     * @return mixed|\Illuminate\Support\Fluent
+     */
+    public static function runUnless($boolean, ...$arguments)
+    {
+        return static::runIf(! $boolean, ...$arguments);
     }
 }

--- a/tests/AsObjectTest.php
+++ b/tests/AsObjectTest.php
@@ -3,6 +3,7 @@
 namespace Lorisleiva\Actions\Tests;
 
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Fluent;
 use Lorisleiva\Actions\Concerns\AsObject;
 
 class AsObjectTest
@@ -36,5 +37,19 @@ it('provides a static run method', function () {
     $result = AsObjectTest::run(1, 2);
 
     // Then it resolves from the container and delegate to the handle method.
+    expect($result)->toBe(3);
+});
+
+it('can be run conditionally', function() {
+    $result = AsObjectTest::runIf(true, 1,2);
+    expect($result)->toBe(3);
+
+    $result = AsObjectTest::runIf(false, 1,2);
+    expect($result)->toBeInstanceOf(Fluent::class);
+
+    $result = AsObjectTest::runUnless(true, 1,2);
+    expect($result)->toBeInstanceOf(Fluent::class);
+
+    $result = AsObjectTest::runUnless(false, 1,2);
     expect($result)->toBe(3);
 });


### PR DESCRIPTION
This refers to #173 and adds the methods `SomeAction::runIf($boolean)` and `SomeAction::runUnless($boolean)`. There are also some tests. The implementation is analogous to the `AsJob` trait.

As these changes are backward compatible I think it warrants only a minor version bump.