### PR TITLE
change abstract class to interface 

### DIFF
--- a/src/DesignPatterns/CommandDesignPattern.php
+++ b/src/DesignPatterns/CommandDesignPattern.php
@@ -8,7 +8,7 @@ use Lorisleiva\Actions\BacktraceFrame;
 use Lorisleiva\Actions\Concerns\AsCommand;
 use Lorisleiva\Actions\Decorators\CommandDecorator;
 
-class CommandDesignPattern extends DesignPattern
+class CommandDesignPattern implements DesignPattern
 {
     public function getTrait(): string
     {

--- a/src/DesignPatterns/ControllerDesignPattern.php
+++ b/src/DesignPatterns/ControllerDesignPattern.php
@@ -7,7 +7,7 @@ use Lorisleiva\Actions\BacktraceFrame;
 use Lorisleiva\Actions\Concerns\AsController;
 use Lorisleiva\Actions\Decorators\ControllerDecorator;
 
-class ControllerDesignPattern extends DesignPattern
+class ControllerDesignPattern implements DesignPattern
 {
     public function getTrait(): string
     {

--- a/src/DesignPatterns/DesignPattern.php
+++ b/src/DesignPatterns/DesignPattern.php
@@ -4,11 +4,11 @@ namespace Lorisleiva\Actions\DesignPatterns;
 
 use Lorisleiva\Actions\BacktraceFrame;
 
-abstract class DesignPattern
+interface DesignPattern
 {
-    abstract public function getTrait(): string;
+    public function getTrait(): string;
 
-    abstract public function recognizeFrame(BacktraceFrame $frame): bool;
+    public function recognizeFrame(BacktraceFrame $frame): bool;
 
-    abstract public function decorate($instance, BacktraceFrame $frame);
+    public function decorate($instance, BacktraceFrame $frame);
 }

--- a/src/DesignPatterns/ListenerDesignPattern.php
+++ b/src/DesignPatterns/ListenerDesignPattern.php
@@ -8,7 +8,7 @@ use Lorisleiva\Actions\BacktraceFrame;
 use Lorisleiva\Actions\Concerns\AsListener;
 use Lorisleiva\Actions\Decorators\ListenerDecorator;
 
-class ListenerDesignPattern extends DesignPattern
+class ListenerDesignPattern implements DesignPattern
 {
     public function getTrait(): string
     {


### PR DESCRIPTION
in this situation i think it's better to use interface instead of abstract class because only visibility and return type are identified 