### PR TITLE
Feat/add service contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,10 @@
         "test-coverage": "vendor/bin/pest --coverage-html coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/src/Contracts/BaseActionContract.php
+++ b/src/Contracts/BaseActionContract.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Lorisleiva\Actions\Contracts;
+
+use Closure;
+use Illuminate\Foundation\Bus\PendingDispatch;
+use Lorisleiva\Actions\ActionPendingChain;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use Mockery\MockInterface;
+
+interface BaseActionContract
+{
+    // AsObject
+    public static function make();
+    public static function run(...$arguments);
+    public static function runIf($boolean, ...$arguments);
+    public static function runUnless($boolean, ...$arguments);
+
+    // AsJob
+    public static function makeJob(...$arguments): JobDecorator;
+    public static function makeUniqueJob(...$arguments): UniqueJobDecorator;
+    public static function dispatch(...$arguments): PendingDispatch;
+    public static function dispatchIf($boolean, ...$arguments);
+    public static function dispatchUnless($boolean, ...$arguments);
+    public static function dispatchSync(...$arguments);
+    public static function dispatchNow(...$arguments);
+    public static function dispatchAfterResponse(...$arguments): void;
+    public static function withChain($chain): ActionPendingChain;
+    public static function assertPushed($times = null, Closure $callback = null): void;
+    public static function assertNotPushed(Closure $callback = null): void;
+    public static function assertPushedOn(string $queue, $times = null, Closure $callback = null): void;
+
+    // AsFake
+    public static function mock(): MockInterface;
+    public static function spy(): MockInterface;
+    public static function partialMock(): MockInterface;
+    public static function shouldRun();
+    public static function shouldNotRun();
+    public static function allowToRun();
+    public static function isFake(): bool;
+    public static function clearFake(): void;
+}

--- a/tests/BaseActionContractTest.php
+++ b/tests/BaseActionContractTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Support\Collection;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Contracts\BaseActionContract;
+use Reflection;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+
+interface DoesNothing extends BaseActionContract
+{
+    public function handle(): string;
+}
+
+class DoNothing
+{
+    use AsAction;
+
+    public function handle(): string
+    {
+        return 'did nothing';
+    }
+}
+
+class FailToImplementHandle
+{
+    use AsAction;
+}
+
+class FailsToUseConcern
+{
+    public function handle(): string
+    {
+        return 'did nothing';
+    }
+}
+
+it('actually does something, sanity check for base feature functionality', function () {
+    $baseContractReflection = new ReflectionClass(BaseActionContract::class);
+    $doesNothingReflection = new ReflectionClass(DoesNothing::class);
+    $concernReflection = new ReflectionClass(FailsToUseConcern::class);
+
+    $unimplementedMethods = getClassMethodStubs($doesNothingReflection)->diff(
+        getClassMethodStubs($concernReflection)->toArray(),
+    );
+
+    $this->assertCount(
+        count($baseContractReflection->getMethods()),
+        $unimplementedMethods,
+    );
+});
+
+it('fulfills the base interface', function () {
+    $doNothingReflection = new ReflectionClass(DoNothing::class);
+    $doesNothingReflection = new ReflectionClass(DoesNothing::class);
+
+    $unimplementedMethods = getClassMethodStubs($doesNothingReflection)->diff(
+        getClassMethodStubs($doNothingReflection)->toArray(),
+    );
+
+    $errorMessage = 'Missing concrete implementations in the AsAction concern for the following methods in the BaseActionContract. Please add an implementation or update the contract.
+[
+    ' . implode('
+    ', $unimplementedMethods->toArray()) . '
+]';
+
+    $this->assertCount(0, $unimplementedMethods, $errorMessage);
+});
+
+it('checks for extra methods defined on service contract', function () {
+    $doesNothingReflection = new ReflectionClass(DoesNothing::class);
+    $handleFailReflection = new ReflectionClass(FailToImplementHandle::class);
+
+    $unimplementedMethods = getClassMethodStubs($doesNothingReflection)->diff(
+        getClassMethodStubs($handleFailReflection)->toArray(),
+    );
+
+    $this->assertCount(
+        1,
+        $unimplementedMethods,
+        'More or less than one method is missing from the failToImplementHandle class',
+    );
+
+    $this->assertSame('public function handle(): string;', $unimplementedMethods->first());
+});
+
+/**
+ * Take a class reflection and return string interpolations for all
+ * methods. Removes abstract declarations from interface classes
+ * Seems like there should be a better way to check validity.
+ */
+function getClassMethodStubs(ReflectionClass $reflection): Collection
+{
+    $isInterface = $reflection->isInterface();
+
+    return collect($reflection->getMethods())->map(function (ReflectionMethod $method) use ($isInterface) {
+        $modifiers = implode(' ', Reflection::getModifierNames($method->getModifiers()));
+        $name = $method->getName();
+        $return = is_null($method->getReturnType()) ? '' : ': ' . $method->getReturnType()->getName();
+        $parameters = '';
+
+        if (count($method->getParameters()) > 0) {
+            $parameters = implode(
+                ', ',
+                collect($method->getParameters())->map(
+                    function (ReflectionParameter $parameter) {
+                        $type = is_null($parameter->getType()) ? '' : $parameter->getType()->getName() .  ' ';
+                        $variadic = $parameter->isVariadic() ? '...' : '';
+                        return $type . $variadic . '$' . $parameter->getName();
+                    }
+                )->toArray(),
+            );
+        }
+
+        $concatenated = "$modifiers function $name($parameters)$return;";
+        return $isInterface ? str_replace('abstract ', '', $concatenated) : $concatenated;
+    });
+};


### PR DESCRIPTION
This PR adds a contract that can be extended for any actions in a user's application. This allows for easy registration of any action using the full service pattern. For example:

```php
interface DoesSomething extends BaseActionContract
{
    public function handle(): string;
}

class DoSomething implements DoesSomething
{
    use AsAction;

    // ...
}

class LivewireComponent extends Component
{
    public function render()
    {
        return app(DoesSomething::class)->run();
    }
}

```

The base action contract will automatically add every single method from the `AsAction` concern to the interface. This is not strictly necessary for the service container to work, but it does ensure that when the interface is consumed static analysis will be able to recognize what methods are available to the service. In this example, calling the `run` method would work without the `BaseActionContract`; but phpstorm, intellephense, and phpstan would all be pretty upset about it.

I have already used this pattern in existing applications, but that means any updates to any of the function headers will break my contracts so it would be useful to have something in the repo itself. I added a test to help keep up the contract with any changes that need to be made to the concern, but I understand if this is too much of a pain to keep up with. I thought it might be helpful to other people, but am open to feedback for how to streamline.

(In that vain, I could not for the life of me find a simple method to check if one class is capable of implementing an interface. Seems like there should be a way to do that. Just implementing the interface caused an exception to be thrown before a test could be run. 🤔 I ended up writing a massive to string interpolator to reflect the classes and manually compare the method declarations.)

Incidentally, aside from the minor maintenance cost of keeping the contract in sync, this should be an easy minor version update. It is completely tested and completely non-breaking. It changes nothing about usage for anyone who does not want to use it but would be a life-saver for those who do 😍 
