### PR TITLE
Fix controller middleware not resolving (#199)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
           - laravel: "^8.67"
             testbench: "^6.23"
           - laravel: "^9.0"
-            testbench: "^7.0"
+            testbench: "7.0"
         exclude:
           - php: "8.0"
             laravel: "^8.67"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,10 @@ jobs:
         include:
           - laravel: "^8.67"
             testbench: "^6.23"
+            testbench-core: "^6.27"
           - laravel: "^9.0"
             testbench: "7.0"
+            testbench-core: "7.0"
         exclude:
           - php: "8.0"
             laravel: "^8.67"
@@ -45,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "orchestra/testbench-core:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "orchestra/testbench-core:${{ matrix.testbench-core }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "orchestra/testbench-core:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "orchestra/testbench": "7.0.0",
         "orchestra/testbench-core": "7.0.0",
-        "pestphp/pest": "1.21.3",
+        "pestphp/pest": "^1.2",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",
-        "pestphp/pest": "^1.2",
+        "pestphp/pest": "1.21.3",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.15|^9.0",
+        "illuminate/contracts": "^8.15 || 9.0 - 9.34 || ^9.36",
         "lorisleiva/lody": "^0.3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "lorisleiva/lody": "^0.3.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "7.0.0",
         "pestphp/pest": "1.21.3",
         "phpunit/phpunit": "^9.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "7.0.0",
+        "orchestra/testbench-core": "7.0.0",
         "pestphp/pest": "1.21.3",
         "phpunit/phpunit": "^9.5"
     },

--- a/src/Concerns/AsController.php
+++ b/src/Concerns/AsController.php
@@ -13,4 +13,14 @@ trait AsController
     {
         return $this->handle(...$arguments);
     }
+
+    /**
+     * This empty method is required to enable controller middleware on the action.
+     * @see https://github.com/lorisleiva/laravel-actions/issues/199
+     * @return void
+     */
+    public function getMiddleware()
+    {
+        // ...
+    }
 }

--- a/tests/AsControllerWithMiddlewareTest.php
+++ b/tests/AsControllerWithMiddlewareTest.php
@@ -11,10 +11,14 @@ class AsControllerWithMiddlewareTest
 {
     use AsController;
 
+    public static int $middlewareCounter = 0;
+
     public function getControllerMiddleware()
     {
         return [
             function (Request $request, $next) {
+                static::$middlewareCounter++;
+
                 if ($request->get('operation') === 'middleware') {
                     return response()->json(['caught by middleware']);
                 }
@@ -42,3 +46,47 @@ it('can register controller middleware', function () {
     // Then we receive a successful response.
     $response->assertOk()->assertExactJson(['caught by middleware']);
 });
+
+
+it('works with route middleware too', function () {
+    // Given the action is registered as a controller with a route middleware.
+    Route::post('/calculator', AsControllerWithMiddlewareTest::class)
+        ->middleware(RouteMiddleware::class);
+
+    // When we call that route.
+    $response = $this->postJson('/calculator', [
+        'operation' => 'route',
+    ]);
+
+    // Then we were intercepted by the route middleware.
+    $response->assertOk()->assertExactJson(['caught by route middleware']);
+});
+
+it('calls route and controller middleware exactly once', function () {
+    // Given the action is registered as a controller with a route middleware.
+    Route::post('/calculator', AsControllerWithMiddlewareTest::class)
+        ->middleware(RouteMiddleware::class);
+
+    // When we call that route.
+    $response = $this->postJson('/calculator');
+
+    // The we were intercepted by both the route and the controller middleware exactly one.
+    expect(RouteMiddleware::$counter)->toBe(1);
+    expect(AsControllerWithMiddlewareTest::$middlewareCounter)->toBe(1);
+});
+
+class RouteMiddleware
+{
+    public static int $counter = 0;
+
+    public function handle(Request $request, $next)
+    {
+        static::$counter++;
+
+        if ($request->get('operation') === 'route') {
+            return response()->json(['caught by route middleware']);
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/AsControllerWithMiddlewareTest.php
+++ b/tests/AsControllerWithMiddlewareTest.php
@@ -34,6 +34,12 @@ class AsControllerWithMiddlewareTest
     }
 }
 
+beforeEach(function () {
+    // Given we reset the static variables.
+    AsControllerWithMiddlewareTest::$middlewareCounter = 0;
+    RouteMiddleware::$counter = 0;
+});
+
 it('can register controller middleware', function () {
     // Given the action is registered as a controller.
     Route::post('/calculator', AsControllerWithMiddlewareTest::class);

--- a/tests/AsJobSerializedTest.php
+++ b/tests/AsJobSerializedTest.php
@@ -56,13 +56,11 @@ it('serialises Eloquent models within the parameters', function () {
 
     // Then the model parameter has been serialised into a ModelIdentifier.
     $firstParameter = (array) data_get($serializedJob, 'parameters.0');
-    expect($firstParameter)->toBe([
-        '__PHP_Incomplete_Class_Name' => ModelIdentifier::class,
-        'class' => get_class($model),
-        'id' => $model->id,
-        'relations' => [],
-        'connection' => 'sqlite',
-    ]);
+    expect($firstParameter['__PHP_Incomplete_Class_Name'])->toBe(ModelIdentifier::class)
+        ->and($firstParameter['class'])->toBe(get_class($model))
+        ->and($firstParameter['id'])->toBe($model->id)
+        ->and($firstParameter['relations'])->toBe([])
+        ->and($firstParameter['connection'])->toBe("sqlite");
 });
 
 it('unserialises Eloquent models within the parameters', function () {
@@ -93,13 +91,11 @@ it('serialises Eloquent collections within the parameters', function () {
 
     // Then the collection parameter has been serialised into a ModelIdentifier.
     $firstParameter = (array) data_get($serializedJob, 'parameters.0');
-    expect($firstParameter)->toBe([
-        '__PHP_Incomplete_Class_Name' => ModelIdentifier::class,
-        'class' => get_class($modelA),
-        'id' => $collection->pluck('id')->toArray(),
-        'relations' => [],
-        'connection' => 'sqlite',
-    ]);
+    expect($firstParameter['__PHP_Incomplete_Class_Name'])->toBe(ModelIdentifier::class)
+        ->and($firstParameter['class'])->toBe(get_class($modelA))
+        ->and($firstParameter['id'])->toBe($collection->pluck('id')->toArray())
+        ->and($firstParameter['relations'])->toBe([])
+        ->and($firstParameter['connection'])->toBe("sqlite");
 });
 
 it('unserialises Eloquent collections within the parameters', function () {


### PR DESCRIPTION
Since version `9.35.0` of the Laravel framework, a PR was merged that changed the way controller middleware were resolved which lead to action middleware not being resolved.

A follow-up PR was implemented on `laravel/framework` (https://github.com/laravel/framework/pull/44590) to enable Laravel Actions to keep its current behaviour whilst making sure the new behaviour from 9.35.0 is not broken.

The goal of this PR is to perform the final update on Laravel Actions which leverages the latest PR on the framework.

Note that this fix will only work once a new version of the framework is published (anything that comes after `9.35.1`).

Fix #199.