### PR TITLE
Make InteractsWithIO::$components protected property accessible on CommandDecorator

### DIFF
--- a/src/Decorators/CommandDecorator.php
+++ b/src/Decorators/CommandDecorator.php
@@ -28,11 +28,6 @@ class CommandDecorator extends Command
         parent::__construct();
     }
 
-    public function getCommandComponents():Factory
-    {
-        return $this->components;
-    }
-
     public function handle()
     {
         if ($this->hasMethod('asCommand')) {
@@ -42,5 +37,10 @@ class CommandDecorator extends Command
         if ($this->hasMethod('handle')) {
             return $this->resolveAndCallMethod('handle', ['command' => $this]);
         }
+    }
+
+    public function getComponents():Factory
+    {
+        return $this->components;
     }
 }

--- a/src/Decorators/CommandDecorator.php
+++ b/src/Decorators/CommandDecorator.php
@@ -3,6 +3,7 @@
 namespace Lorisleiva\Actions\Decorators;
 
 use Illuminate\Console\Command;
+use \Illuminate\Console\View\Components\Factory;
 use Lorisleiva\Actions\Concerns\DecorateActions;
 use Lorisleiva\Actions\Exceptions\MissingCommandSignatureException;
 
@@ -25,6 +26,11 @@ class CommandDecorator extends Command
         }
 
         parent::__construct();
+    }
+
+    public function getCommandComponents():Factory
+    {
+        return $this->components;
     }
 
     public function handle()


### PR DESCRIPTION
see [#205](https://github.com/lorisleiva/laravel-actions/issues/205)

That pull request makes possible to access Illuminate\Console\Command::$components protected property from asCommand method.

```php
namespace App\Actions;

use Illuminate\Console\Command;

class ConsoleTestAction extends Action {
    public string $commandSignature = 'test-action';

    public function asCommand(Command $command): void {
        $command->getComponents()->info('Done!');
    }
}
```

**Result:**
![image](https://user-images.githubusercontent.com/2463299/197000012-ab913b08-36d1-43dc-9d6d-a14b77f93b44.png)


I dont know if is the best choice.
Maybe the best way is to open a pull request on laravel repo.

