### PR TITLE
Implement option to get a validated input using key

### DIFF
--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -155,9 +155,9 @@ trait ValidateActions
         $response->authorize();
     }
 
-    public function validated($key = null, $default = null): array
+    public function validated($key = null, $default = null): mixed
     {
-        return $this->validator->validated();
+        return data_get($this->validator->validated(), $key, $default);
     }
 
     protected function prepareForValidation()


### PR DESCRIPTION
Although the `ActionRequest::validated` method accepts the `$key` and `$default` parameters (for `FormRequest` compatibility), these parameters are not used as implemented in Laravel ([#36807](https://github.com/laravel/framework/pull/36807)).

This PR fixes that.

Previous Behavior:
```php
public function handle(ActionRequest $request) {
    $validated = $request->validated(); // Returns an array

    $password = $request->validated('password'); // Still returns an array
}
```

New Behavior:
```php
public function handle(ActionRequest $request) {
    $validated = $request->validated(); // Returns an array

    $password = $request->validated('password'); // Still returns the validated `password` field's value
}
```