### PR TITLE
Update AsController.php

### DIFF
--- a/src/Concerns/AsController.php
+++ b/src/Concerns/AsController.php
@@ -21,6 +21,6 @@ trait AsController
      */
     public function getMiddleware()
     {
-        // ...
+        return [];
     }
 }


### PR DESCRIPTION
Using LaravelActions with dingo API causes an exception, as it calls getMiddleware(), which expects an array when using array_merge.