### PR TITLE
AsListener EventDiscovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "lorisleiva/lody": "^0.3.0"
     },
     "require-dev": {
-        "orchestra/testbench": "7.0.0",
-        "orchestra/testbench-core": "7.0.0",
+        "orchestra/testbench": "^7.0.0",
+        "orchestra/testbench-core": "^7.0.0",
         "pestphp/pest": "^1.2",
         "phpunit/phpunit": "^9.5"
     },
@@ -43,7 +43,10 @@
     },
     "scripts": {
         "test": "vendor/bin/pest --colors=always",
-        "test-coverage": "vendor/bin/pest --coverage-html coverage"
+        "test-coverage": "vendor/bin/pest --coverage-html coverage",
+        "post-autoload-dump": [
+            "@php vendor/bin/testbench package:discover --ansi"
+        ]
     },
     "config": {
         "sort-packages": true,
@@ -54,7 +57,8 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Lorisleiva\\Actions\\ActionServiceProvider"
+                "Lorisleiva\\Actions\\ActionServiceProvider",
+                "Lorisleiva\\Actions\\ActionEventServiceProvider"
             ],
             "aliases": {
                 "Action": "Lorisleiva\\Actions\\Facades\\Actions"

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "laravel": {
             "providers": [
                 "Lorisleiva\\Actions\\ActionServiceProvider",
-                "Lorisleiva\\Actions\\ActionEventServiceProvider"
+                "Lorisleiva\\Actions\\EventServiceProvider"
             ],
             "aliases": {
                 "Action": "Lorisleiva\\Actions\\Facades\\Actions"

--- a/config/actions.php
+++ b/config/actions.php
@@ -1,0 +1,24 @@
+<?php
+return [
+
+    'listeners' => [
+
+        // Automatically discover asListener events
+        'discovery' => [
+            'enabled' => false,
+
+            /*
+            / Provide own Actions Path if needed.
+            / Application's `Actions` dir is used by default
+            */
+            'paths' => null,
+//            'paths' => [
+//                app_path('Actions'),
+//                base_path('Modules/Example/Actions'),
+//            ],
+
+
+        ],
+
+    ]
+];

--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -24,7 +24,12 @@ class ActionServiceProvider extends ServiceProvider
 
     public function boot()
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/actions.php', 'actions');
+
         if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../config/actions.php' => config_path('actions.php'),
+            ], 'actions-config');
             // publish Stubs File
             $this->publishes([
                 __DIR__ . '/Console/stubs/action.stub' => base_path('stubs/action.stub'),

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Lorisleiva\Actions;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Reflector;
+use Lorisleiva\Actions\Concerns\AsListener;
+use Lorisleiva\Lody\Lody;
+
+class EventServiceProvider extends ServiceProvider
+{
+
+    public function shouldDiscoverEvents()
+    {
+        return config('actions.listeners.discovery.enabled');
+    }
+
+    public function discoverEvents(): array
+    {
+        $listeners = $this->discoverListeners();
+
+        $discoveredEvents = [];
+
+        foreach ($listeners as $listener => $events) {
+            foreach ($events as $event) {
+                if (! isset($discoveredEvents[$event])) {
+                    $discoveredEvents[$event] = [];
+                }
+
+                $discoveredEvents[$event][] = $listener;
+            }
+        }
+
+        return $discoveredEvents;
+
+    }
+
+    protected function discoverListeners(): array
+    {
+        return Lody::classes($this->discoverEventsWithin())
+                   ->hasTrait(AsListener::class)
+                   ->filter(function ($class): bool {
+                       return method_exists($class, 'handle');
+                   })
+                   ->mapWithKeys(function ($class) {
+                       $method = (method_exists($class, 'asListener'))
+                           ? new \ReflectionMethod($class, 'asListener')
+                           : new \ReflectionMethod($class, 'handle');
+
+                       return [
+                           $class.'@handle' =>
+                               Reflector::getParameterClassNames($method->getParameters()[0])
+                       ];
+                   })
+                   ->filter()
+                   ->toArray();
+    }
+
+    protected function discoverEventsWithin()
+    {
+        return config('actions.listeners.discovery.paths') ?? [
+            $this->app->path('Actions'),
+        ];
+    }
+
+
+}

--- a/tests/AsListenerDiscoveredTest.php
+++ b/tests/AsListenerDiscoveredTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Support\Facades\Event;
+use Lorisleiva\Actions\Concerns\AsListener;
+use Lorisleiva\Actions\EventServiceProvider;
+use Lorisleiva\Actions\Tests\Stubs\AsListenerAction;
+use Lorisleiva\Actions\Tests\Stubs\AsListenerHandleAction;
+use Lorisleiva\Actions\Tests\Stubs\OperationRequestedEvent;
+
+uses(DiscoversListeners::class);
+
+dataset('ListenerActions', [
+    'Action@asListener' => [AsListenerAction::class],
+    'Action@handle' => [AsListenerHandleAction::class],
+]);
+
+beforeEach(function () {
+    // And reset the static properties between each test.
+    AsListenerAction::$constructed = 0;
+    AsListenerAction::$handled = 0;
+    AsListenerAction::$latestResult = null;
+    AsListenerHandleAction::$constructed = 0;
+    AsListenerHandleAction::$handled = 0;
+    AsListenerHandleAction::$latestResult = null;
+});
+
+it('can run as an auto-discovered event listener', function ($class) {
+    // When we dispatch an OperationRequestedEvent.
+    Event::dispatch(new OperationRequestedEvent('addition', 1, 2));
+
+    // Then the action was triggered as a listener.
+    expect($class::$latestResult)->toBe(3);
+})->with('ListenerActions');
+
+it('is constructed and handled everytime it is triggered as a discovered listener', function ($class) {
+    // When we dispatch two OperationRequestedEvents.
+    Event::dispatch(new OperationRequestedEvent('addition', 1, 2));
+    Event::dispatch(new OperationRequestedEvent('addition', 1, 2));
+
+    // Then the action was constructed and handled twice.
+    expect($class::$constructed)->toBe(2);
+    expect($class::$handled)->toBe(2);
+})->with('ListenerActions');

--- a/tests/DiscoversListeners.php
+++ b/tests/DiscoversListeners.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+trait DiscoversListeners
+{
+    public function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('actions.listeners.discovery.enabled', true);
+        $app['config']->set('actions.listeners.discovery.paths', [__DIR__.'/Stubs']);
+    }
+}

--- a/tests/Stubs/AsListenerAction.php
+++ b/tests/Stubs/AsListenerAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\Stubs;
+
+use Lorisleiva\Actions\Concerns\AsListener;
+
+class AsListenerAction
+{
+    use AsListener;
+
+    public static int $constructed = 0;
+    public static int $handled = 0;
+    public static ?int $latestResult;
+
+    public function __construct()
+    {
+        static::$constructed++;
+    }
+
+    public function handle($operation, $left, $right): void
+    {
+        static::$handled++;
+        static::$latestResult = $operation === 'addition'
+            ? $left + $right
+            : $left - $right;
+    }
+
+    public function asListener(OperationRequestedEvent $event): void
+    {
+        $this->handle($event->operation, $event->left, $event->right);
+    }
+}

--- a/tests/Stubs/AsListenerHandleAction.php
+++ b/tests/Stubs/AsListenerHandleAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\Stubs;
+
+use Lorisleiva\Actions\Concerns\AsListener;
+
+class AsListenerHandleAction
+{
+    use AsListener;
+
+    public static int $constructed = 0;
+    public static int $handled = 0;
+    public static ?int $latestResult;
+
+    public function __construct()
+    {
+        static::$constructed++;
+    }
+
+    public function handle(OperationRequestedEvent $event): void
+    {
+        static::$handled++;
+        static::$latestResult = $event->operation === 'addition'
+            ? $event->left + $event->right
+            : $event->left - $event->right;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace Lorisleiva\Actions\Tests;
 
 use Lorisleiva\Actions\ActionServiceProvider;
+use Lorisleiva\Actions\EventServiceProvider;
+use Lorisleiva\Lody\Lody;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -11,11 +13,7 @@ class TestCase extends Orchestra
     {
         return [
             ActionServiceProvider::class,
+            EventServiceProvider::class
         ];
-    }
-
-    public function getEnvironmentSetUp($app)
-    {
-        //
     }
 }


### PR DESCRIPTION
I often use EventDiscovery in my projects - I missed it in this package :)
Actually, native EventDiscovery could discover Actions, but it registers events based on `handle` method parameters instead of `asListener`

The feature works pretty much the same as Laravel's Event Discovery - it uses **Lody** instead of **Finder** as a difference

- I used an additional `EventServiceProvider` instead of the main `ActionServiceProvider` because laravel uses only these services in the `event:cache` command
- Since we are implementing all cases in the Action class, those without Event Class in `handle` method parameter are also registered

- Discovering Events may looks weird, because half is done by Collection, but second using hard-coded array flip.
I tried different ways to make it done using Collection grouping but decided to leave it as it is because of performance reasons & complex/confusing operations - Maybe somebody knows a better way :)



Other changes:
- Updated Orchestra TestBench, because the previous version throws an error in `package:discovery` command
- The command above was needed to register dependent ServiceProviders (Lody in this particular case)


TODO
- [ ] Readme
- [ ] Refactor & Publish EventServiceProvider for per-project customization such as path-resolving
- [ ] Consider doing the above instead of using the config file