### PR TITLE
bugfix(routing): Resolve a routing issue found in octane

### DIFF
--- a/src/Concerns/AsController.php
+++ b/src/Concerns/AsController.php
@@ -2,6 +2,9 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+use Lorisleiva\Actions\Decorators\ControllerDecorator;
+use Illuminate\Support\Facades\Route;
+
 trait AsController
 {
     /**
@@ -11,7 +14,7 @@ trait AsController
      */
     public function __invoke(...$arguments)
     {
-        return $this->handle(...$arguments);
+        return (new ControllerDecorator($this, Route::current()))->execute();
     }
 
     /**

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -54,6 +54,13 @@ class ControllerDecorator
         }, $this->middleware);
     }
 
+    public function execute()
+    {
+        return $this->run(
+            $this->getDefaultRouteMethod()
+        );
+    }
+
     public function callAction($method, $parameters)
     {
         return $this->__invoke($method);
@@ -158,6 +165,10 @@ class ControllerDecorator
     protected function resolveFromRouteAndCall($method)
     {
         $this->container = Container::getInstance();
+
+        $router = app('router');
+        $router->substituteBindings($this->route);
+        $router->substituteImplicitBindings($this->route);
 
         $arguments = $this->resolveClassMethodDependencies(
             $this->route->parametersWithoutNulls(),


### PR DESCRIPTION
## Description

When using octane, I found that subsequent requests would often fail, with two different errors showing:

> App\xxxxx::handle(): Argument #1 ($model) must be of type App\Model\Xxxxx, string given, called in /var/task/vendor/lorisleiva/laravel-actions/src/Concerns/AsController.php on line 14

> Too few arguments to function App\xxxxx::handle(), 0 passed

From these errors, I can determine that route binding and dependancy injection is breaking on occasion. As such we need to ensure that we are resolving the arguments correctly before calling the handle() method.

## Changes Made

File `src/Concerns/AsController.php`
- Add a new execute() fn that essentially runs the ControllerDecorator again. This is not ideal but works for now.

File `src/Decorators/ControllerDecorator.php`
- Ensure that we have substituted route bindings, _this seems to be the main fix for the problem_
- Added an `execute` method to call the default run function

## Issues remaining

I feel like there is a double up now, that ControllerDecorator runs twice as it seems to resolve things like jsonResponse and htmlResponse. 
This is why the new `execute` function uses `run` and not `callAction` or `__invoke`

## Testing - needs work

This needs to be tested in a replicable octane environment, for the moment I tested by manually disabling the call to `replaceRouteMethod` in the decorator's constructor and then updating the `AsController::__invoke` method to look like so:

```
$decorator = (new ControllerDecorator($this, \Route::current()));
$decorator->replaceRouteMethod();
return $decorator->execute();
```

This would then cause the default `AsController::__invoke` function to run first, first like it does in subsequent Octane calls

## Related Issues

- https://github.com/lorisleiva/laravel-actions/issues/202