### PR TITLE
Add option to configure custom job decorator classes

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -3,15 +3,24 @@
 namespace Lorisleiva\Actions;
 
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Routing\Router;
 use Lorisleiva\Actions\Concerns\AsCommand;
 use Lorisleiva\Actions\Concerns\AsController;
 use Lorisleiva\Actions\Concerns\AsFake;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
 use Lorisleiva\Actions\DesignPatterns\DesignPattern;
 use Lorisleiva\Lody\Lody;
 
 class ActionManager
 {
+    /** @var class-string<JobDecorator> */
+    public static string $jobDecorator = JobDecorator::class;
+
+    /** @var class-string<JobDecorator&ShouldBeUnique> */
+    public static string $uniqueJobDecorator = UniqueJobDecorator::class;
+
     /** @var DesignPattern[] */
     protected array $designPatterns = [];
 
@@ -21,6 +30,22 @@ class ActionManager
     public function __construct(array $designPatterns = [])
     {
         $this->setDesignPatterns($designPatterns);
+    }
+
+    /**
+     * @param class-string<JobDecorator> $jobDecoratorClass
+     */
+    public static function useJobDecorator(string $jobDecoratorClass): void
+    {
+        static::$jobDecorator = $jobDecoratorClass;
+    }
+
+    /**
+     * @param class-string<JobDecorator&ShouldBeUnique> $uniqueJobDecoratorClass
+     */
+    public static function useUniqueJobDecorator(string $uniqueJobDecoratorClass): void
+    {
+        static::$uniqueJobDecorator = $uniqueJobDecoratorClass;
     }
 
     public function setDesignPatterns(array $designPatterns): ActionManager

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Fluent;
+use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\ActionPendingChain;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
@@ -25,7 +26,7 @@ trait AsJob
             return static::makeUniqueJob(...$arguments);
         }
 
-        return new JobDecorator(static::class, ...$arguments);
+        return new ActionManager::$jobDecorator(static::class, ...$arguments);
     }
 
     /**
@@ -34,7 +35,7 @@ trait AsJob
      */
     public static function makeUniqueJob(...$arguments): UniqueJobDecorator
     {
-        return new UniqueJobDecorator(static::class, ...$arguments);
+        return new ActionManager::$uniqueJobDecorator(static::class, ...$arguments);
     }
 
     /**
@@ -122,8 +123,8 @@ trait AsJob
         }
 
         $decoratorClass = static::jobShouldBeUnique()
-            ? UniqueJobDecorator::class
-            : JobDecorator::class;
+            ? ActionManager::$uniqueJobDecorator
+            : ActionManager::$jobDecorator;
 
         $count = Queue::pushed($decoratorClass, function (JobDecorator $job, $queue) use ($callback) {
             if (! $job->decorates(static::class)) {

--- a/tests/ActionManagerTest.php
+++ b/tests/ActionManagerTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use Lorisleiva\Actions\ActionManager;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
 use Lorisleiva\Actions\Facades\Actions;
+use Lorisleiva\Actions\Tests\Stubs\CustomJobDecorator;
+use Lorisleiva\Actions\Tests\Stubs\CustomUniqueJobDecorator;
 
 it('resolves from the container', function () {
     $manager = app(ActionManager::class);
@@ -20,4 +24,17 @@ it('resolves as a singleton', function () {
     $managerB = app(ActionManager::class);
 
     expect($managerA)->toBe($managerB);
+});
+
+it('stores the configured job decorator classes', function () {
+    expect(ActionManager::$jobDecorator)->toBe(JobDecorator::class);
+    expect(ActionManager::$uniqueJobDecorator)->toBe(UniqueJobDecorator::class);
+});
+
+it('can register custom job decorator classes', function () {
+    ActionManager::useJobDecorator(CustomJobDecorator::class);
+    ActionManager::useUniqueJobDecorator(CustomUniqueJobDecorator::class);
+
+    expect(ActionManager::$jobDecorator)->toBe(CustomJobDecorator::class);
+    expect(ActionManager::$uniqueJobDecorator)->toBe(CustomUniqueJobDecorator::class);
 });

--- a/tests/AsJobTest.php
+++ b/tests/AsJobTest.php
@@ -6,9 +6,12 @@ use Carbon\Carbon;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Queue;
+use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\Concerns\AsJob;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use Lorisleiva\Actions\Tests\Stubs\CustomJobDecorator;
+use Lorisleiva\Actions\Tests\Stubs\CustomUniqueJobDecorator;
 
 class AsJobTest
 {
@@ -79,7 +82,7 @@ it('can be dispatched asynchronously with parameters', function () {
     assertJobPushedWith(AsJobTest::class, $parameters);
 });
 
-it('can make a job statically', function () {
+it('can make a job statically', function (string $expectedJobClass) {
     // Given the following job parameters.
     $parameters = [1, 'two', new Filesystem()];
 
@@ -90,7 +93,7 @@ it('can make a job statically', function () {
     dispatch($job);
 
     // Then the created job is a JobDecorator that kept track of the action and its paremeters.
-    expect($job)->toBeInstanceOf(JobDecorator::class);
+    expect($job)->toBeInstanceOf($expectedJobClass);
     expect($job->getAction())->toBeInstanceOf(AsJobTest::class);
     expect($job->getParameters())->toBe($parameters);
 
@@ -99,16 +102,16 @@ it('can make a job statically', function () {
 
     // And the job was dispatched to the queue.
     assertJobPushed(AsJobTest::class);
-});
+})->with('custom job decorators');
 
-it('can make a unique job statically', function () {
+it('can make a unique job statically', function (string $expectedJobClass) {
     // When we make a unique job from the action.
     $job = AsJobTest::makeUniqueJob();
 
     // Then it returns a UniqueJobDecorator.
-    expect($job)->toBeInstanceOf(UniqueJobDecorator::class);
+    expect($job)->toBeInstanceOf($expectedJobClass);
     expect($job)->toBeInstanceOf(ShouldBeUnique::class);
-});
+})->with('custom unique job decorators');
 
 it('can be dispatched with overridden configurations', function () {
     // When we dispatch a job with the following configurations.

--- a/tests/AsJobWithAssertionsTest.php
+++ b/tests/AsJobWithAssertionsTest.php
@@ -43,7 +43,7 @@ it('asserts an action has been pushed - success', function () {
 
     // Then we can assert it has been dispatched.
     AsJobWithAssertionsTest::assertPushed();
-});
+})->with('custom job decorators');
 
 it('asserts an action has been pushed - failure', function () {
     // Given we don't dispatch the action.
@@ -55,7 +55,7 @@ it('asserts an action has been pushed - failure', function () {
 
     // When we assert that it was pushed.
     AsJobWithAssertionsTest::assertPushed();
-});
+})->with('custom job decorators');
 
 it('asserts an action has not been pushed - success', function () {
     // When we don't dispatch the action.
@@ -63,7 +63,7 @@ it('asserts an action has not been pushed - success', function () {
 
     // Then we can assert it has not been dispatched.
     AsJobWithAssertionsTest::assertNotPushed();
-});
+})->with('custom job decorators');
 
 it('asserts an action has not been pushed - failure', function () {
     // Given we dispatched the action.
@@ -75,7 +75,7 @@ it('asserts an action has not been pushed - failure', function () {
 
     // When we assert that it was not pushed.
     AsJobWithAssertionsTest::assertNotPushed();
-});
+})->with('custom job decorators');
 
 it('asserts an action has been pushed a given amount of times - success', function () {
     // When we dispatch the action twice.
@@ -84,7 +84,7 @@ it('asserts an action has been pushed a given amount of times - success', functi
 
     // Then we can assert it has been dispatched.
     AsJobWithAssertionsTest::assertPushed(2);
-});
+})->with('custom job decorators');
 
 it('asserts an action has been pushed a given amount of times - failure', function () {
     // Given we dispatched the action twice.
@@ -97,7 +97,7 @@ it('asserts an action has been pushed a given amount of times - failure', functi
 
     // When we assert that it was pushed 3 times.
     AsJobWithAssertionsTest::assertPushed(3);
-});
+})->with('custom job decorators');
 
 it('asserts an action has been pushed on a given queue - success', function () {
     // When we dispatch the action on "some-queue".
@@ -106,7 +106,7 @@ it('asserts an action has been pushed on a given queue - success', function () {
 
     // Then we can assert it has been dispatched on that queue.
     AsJobWithAssertionsTest::assertPushedOn('some-queue');
-});
+})->with('custom job decorators');
 
 it('asserts an action has been pushed on a given queue - failure', function () {
     // Given we dispatched the action on "some-queue".
@@ -119,4 +119,4 @@ it('asserts an action has been pushed on a given queue - failure', function () {
 
     // When we pushed it on some other queue.
     AsJobWithAssertionsTest::assertPushedOn('some-other-queue');
-});
+})->with('custom job decorators');

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Application;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
+use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Tests\Stubs\User;
 
@@ -46,7 +47,7 @@ function registerCommands(array $commands): void
 
 function assertJobPushed(string $class, ?Closure $callback = null): void
 {
-    Queue::assertPushed(JobDecorator::class, function (JobDecorator $job) use ($class, $callback) {
+    Queue::assertPushed(ActionManager::$jobDecorator, function (JobDecorator $job) use ($class, $callback) {
         if (! $job->decorates($class)) {
             return false;
         }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,32 @@
 <?php
 
+use Lorisleiva\Actions\ActionManager;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use Lorisleiva\Actions\Tests\Stubs\CustomJobDecorator;
+use Lorisleiva\Actions\Tests\Stubs\CustomUniqueJobDecorator;
 use Lorisleiva\Actions\Tests\TestCase;
 
-uses(TestCase::class)->in(__DIR__);
+uses(TestCase::class)
+    ->afterEach(function () {
+        // Reset any custom job classes so they don't pollute other tests.
+        ActionManager::useJobDecorator(JobDecorator::class);
+        ActionManager::useUniqueJobDecorator(UniqueJobDecorator::class);
+    })
+    ->in(__DIR__);
+
+dataset('custom job decorators', [
+    'default job decorator class' => [JobDecorator::class],
+    'custom job decorator class' => function () {
+        ActionManager::useJobDecorator(CustomJobDecorator::class);
+        return CustomJobDecorator::class;
+    },
+]);
+
+dataset('custom unique job decorators', [
+    'default job decorator class' => [UniqueJobDecorator::class],
+    'custom job decorator class' => function () {
+        ActionManager::useUniqueJobDecorator(CustomUniqueJobDecorator::class);
+        return CustomUniqueJobDecorator::class;
+    },
+]);

--- a/tests/Stubs/CustomJobDecorator.php
+++ b/tests/Stubs/CustomJobDecorator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\Stubs;
+
+use Lorisleiva\Actions\Decorators\JobDecorator;
+
+class CustomJobDecorator extends JobDecorator
+{
+}

--- a/tests/Stubs/CustomUniqueJobDecorator.php
+++ b/tests/Stubs/CustomUniqueJobDecorator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\Stubs;
+
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+
+class CustomUniqueJobDecorator extends UniqueJobDecorator
+{
+}


### PR DESCRIPTION
## Summary

This PR adds the ability to define custom job decorator classes. These custom classes will then get used when using an action as a job. The default implementation is to use the existing `JobDecorator` and `UniqueJobDecorator` classes, so this should be a backwards compatible change.

## Code changes

In order to change the decorator classes, two new methods were added to the `ActionManager`.

- `ActionManager::useJobDecorator(string $jobDecoratorClass)` changes the decorator class that gets used when an action gets turned into a non-unique job
- `ActionManager::useUniqueJobDecorator(string $uniqueJobDecoratorClass)` changes the decorator that gets used when an action gets turned into a unique job

Apart from that, the only non-test code that needed be changed were the `makeJob`, `makeUniqueJob`, and `assertPushed` methods in the `AsJob` trait. These methods will now grab the decorator class from the `ActionManager` at runtime.

## Tests

Since `$jobDecoratorClass` and `$uniqueJobDecoratorClass` are both static properties on the `ActionManager`, I decided to play it extra safe and add a global `afterEach` callback to the test suite which resets them back to their default values. This avoids having to remember to manually reset this in every test case that might change these default settings (as has happened to me when implementing this).

I also added two datasets to more easily check that a given test passes both for the default decorator classes, as well as custom decorator classes.

## Additional Info

I have already tested these changes in a large real-world application and can confirm that they are sufficient to ship first-party integration with Laravel Actions inside Venture. Let me know what you think 😊 

Closes #224 