### PR TITLE
Fix Octane Event using handle instead of asListener

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -4,6 +4,7 @@ namespace Lorisleiva\Actions;
 
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Lorisleiva\Actions\Concerns\AsCommand;
 use Lorisleiva\Actions\Concerns\AsController;
@@ -69,7 +70,7 @@ class ActionManager
         return array_filter($this->getDesignPatterns(), $filter);
     }
 
-    public function extend(string $abstract): void
+    public function extend(Application $app, string $abstract): void
     {
         if ($this->isExtending($abstract)) {
             return;
@@ -79,7 +80,7 @@ class ActionManager
             return;
         }
 
-        app()->extend($abstract, function ($instance) {
+        $app->extend($abstract, function ($instance) {
             return $this->identifyAndDecorate($instance);
         });
 

--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -13,14 +13,15 @@ class ActionServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $manager = new ActionManager([
-            new ControllerDesignPattern(),
-            new ListenerDesignPattern(),
-            new CommandDesignPattern(),
-        ]);
+        $this->app->scoped(ActionManager::class, function () {
+            return new ActionManager([
+                new ControllerDesignPattern(),
+                new ListenerDesignPattern(),
+                new CommandDesignPattern(),
+            ]);
+        });
 
-        $this->app->instance(ActionManager::class, $manager);
-        $this->extendActions($manager);
+        $this->extendActions();
     }
 
     public function boot()
@@ -38,9 +39,13 @@ class ActionServiceProvider extends ServiceProvider
         }
     }
 
-    protected function extendActions(ActionManager $manager)
+    protected function extendActions()
     {
-        $this->app->beforeResolving(function ($abstract, $parameters, Application $app) use ($manager) {
+        $this->app->beforeResolving(function ($abstract, $parameters, Application $app) {
+            if ($abstract === ActionManager::class) {
+                return;
+            }
+
             try {
                 // Fix conflict with package: barryvdh/laravel-ide-helper.
                 // @see https://github.com/lorisleiva/laravel-actions/issues/142
@@ -53,7 +58,7 @@ class ActionServiceProvider extends ServiceProvider
                 return;
             }
 
-            $manager->extend($app, $abstract);
+            $app->make(ActionManager::class)->extend($app, $abstract);
         });
     }
 }

--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Lorisleiva\Actions;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Lorisleiva\Actions\Console\MakeActionCommand;
 use Lorisleiva\Actions\DesignPatterns\CommandDesignPattern;
@@ -39,7 +40,7 @@ class ActionServiceProvider extends ServiceProvider
 
     protected function extendActions(ActionManager $manager)
     {
-        $this->app->beforeResolving(function ($abstract) use ($manager) {
+        $this->app->beforeResolving(function ($abstract, $parameters, Application $app) use ($manager) {
             try {
                 // Fix conflict with package: barryvdh/laravel-ide-helper.
                 // @see https://github.com/lorisleiva/laravel-actions/issues/142
@@ -48,11 +49,11 @@ class ActionServiceProvider extends ServiceProvider
                 return;
             }
 
-            if (! $classExists || app()->resolved($abstract)) {
+            if (! $classExists || $app->resolved($abstract)) {
                 return;
             }
 
-            $manager->extend($abstract);
+            $manager->extend($app, $abstract);
         });
     }
 }


### PR DESCRIPTION
Fixes #136 

This PR seems to fix the issue when using listeners with an application running on Octane where it calls `handle` instead of the `asListener` method.

```
App\Actions\User\SetupCompleted::handle(): Argument #1 ($user) must be of type App\Models\User, App\Events\UserUpdated given, called in /.../vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php on line 424
```

We encountered this issue on listeners that **were not queued (i.e. not implementing `ShouldQueue`)**.

## Cause
After some lengthy debugging, it seemed that the `app()->extend(..` callback in `ActionManager::extend` method was not actually getting called once the listener was resolved when running on Octane. So I tried to figure out which container instance it should be using. 

## Fix
Basically reverted the changes made originally here https://github.com/lorisleiva/laravel-actions/commit/a2e42f09b2ea0bc75ff2ebdcb0bb3153f15c205d as it seems in this case it is correct to use the `Application` instance passed to the `beforeResolving` callback to extend the found action classes.

This seemed to fix the issue for me when running Octane locally. We deployed this fork to our prod environments too (on Vapor) and it works without issue. 

### Possible Breaking Changes
I have had to change the method signature of `ActionManager::extend` to accept an `Application $app` argument. 
Let me know if you can come up with a change that would not require changing this method signature. 

Anyone who has done a workaround to this issue by defining their event listeners like: 
```php
UserEvent::class => [
    [UserAction::class, 'asListener']
]
```

They will get an error after this fix of `Unknown method ListenerDecorator::asListener` and will need to change these back to:
```php
UserEvent::class => [
    UserAction::class,
]
```