### PR TITLE
Fix test broken by Laravel 9.52.6 / 10.8.0

### DIFF
--- a/tests/AsJobTest.php
+++ b/tests/AsJobTest.php
@@ -130,13 +130,13 @@ it('can be dispatched after the response', function () {
     AsJobTest::dispatchAfterResponse();
 
     // Then it is not dispatch immediately.
-    expect(AsJobTest::$handled)->toBe(0);
+    Queue::assertNothingPushed();
 
     // But when the app terminates.
     app()->terminate();
 
     // Then the job was dispatched.
-    expect(AsJobTest::$handled)->toBe(1);
+    Queue::assertPushed(JobDecorator::class);
 });
 
 it('constructs a new job at every dispatch', function () {


### PR DESCRIPTION
Caused by https://github.com/laravel/framework/pull/46806

The afterResponse handler was changed from using `$this->dispatchNow(...)` to `$this->dispatchSync(...)` in the above PR.