### PR TITLE
Add support for listener shouldQueue method

### DIFF
--- a/src/Decorators/ListenerDecorator.php
+++ b/src/Decorators/ListenerDecorator.php
@@ -26,6 +26,15 @@ class ListenerDecorator
         }
     }
 
+    public function shouldQueue(...$arguments)
+    {
+        if ($this->hasMethod('shouldQueue')) {
+            return $this->resolveFromArgumentsAndCall('shouldQueue', $arguments);
+        }
+
+        return true;
+    }
+
     protected function resolveFromArgumentsAndCall($method, $arguments)
     {
         $arguments = $this->resolveClassMethodDependencies(

--- a/tests/AsListenerWithShouldQueueTest.php
+++ b/tests/AsListenerWithShouldQueueTest.php
@@ -15,6 +15,7 @@ class AsListenerWithShouldQueueTest implements ShouldQueue
 
     public static int $constructed = 0;
     public static int $handled = 0;
+    public static int $shouldQueue = 0;
     public static ?int $latestResult;
 
     public function __construct()
@@ -35,6 +36,13 @@ class AsListenerWithShouldQueueTest implements ShouldQueue
     {
         $this->handle($event->operation, $event->left, $event->right);
     }
+
+    public function shouldQueue(OperationRequestedEvent $event): bool
+    {
+        static::$shouldQueue++;
+
+        return true;
+    }
 }
 
 beforeEach(function () {
@@ -44,6 +52,7 @@ beforeEach(function () {
     // And reset the static properties between each test.
     AsListenerWithShouldQueueTest::$constructed = 0;
     AsListenerWithShouldQueueTest::$handled = 0;
+    AsListenerWithShouldQueueTest::$shouldQueue = 0;
     AsListenerWithShouldQueueTest::$latestResult = null;
 });
 
@@ -69,6 +78,7 @@ it('can run as a queued listener', function () {
     // Then the action was triggered as a queued listener.
     expect(AsListenerWithShouldQueueTest::$latestResult)->toBe(3);
     expect(AsListenerWithShouldQueueTest::$handled)->toBe(1);
+    expect(AsListenerWithShouldQueueTest::$shouldQueue)->toBe(1);
 
     // And was constructed twice. Once before and once during the queued job.
     expect(AsListenerWithShouldQueueTest::$constructed)->toBe(2);


### PR DESCRIPTION
This  PR adds support for the below functionality that exists on traditional listeners.

> #### Conditionally Queueing Listeners
> 
> Sometimes, you may need to determine whether a listener should be queued based on some data that are only available at runtime. To accomplish this, a `shouldQueue` method may be added to a listener to determine whether the listener should be queued. If the `shouldQueue` method returns `false`, the listener will not be executed:
> ```php
>     <?php
> 
>     namespace App\Listeners;
> 
>     use App\Events\OrderCreated;
>     use Illuminate\Contracts\Queue\ShouldQueue;
> 
>     class RewardGiftCard implements ShouldQueue
>     {
>         /**
>          * Reward a gift card to the customer.
>          */
>         public function handle(OrderCreated $event): void
>         {
>             // ...
>         }
> 
>         /**
>          * Determine whether the listener should be queued.
>          */
>         public function shouldQueue(OrderCreated $event): bool
>         {
>             return $event->order->subtotal >= 5000;
>         }
>     }
> ```
> _Source: https://laravel.com/docs/10.x/events#conditionally-queueing-listeners_