### PR TITLE
feat: allow custom design patterns

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -61,6 +61,13 @@ class ActionManager
         return $this->designPatterns;
     }
 
+    public function registerDesignPattern(DesignPattern $designPattern): ActionManager
+    {
+        $this->designPatterns[] = $designPattern;
+        
+        return $this;
+    }
+
     public function getDesignPatternsMatching(array $usedTraits): array
     {
         $filter = function (DesignPattern $designPattern) use ($usedTraits) {


### PR DESCRIPTION
This PR allows custom patterns to be registered via:
```php
    $this->app->extend(ActionManager::class, function (ActionManager $actionManager) {
      $actionManager->registerDesignPattern(new FooBarDesignPattern());

      return $actionManager;
    });
```