### PR TITLE
Added docBlock annotations to assist with IDE auto complete for Actions

### DIFF
--- a/src/Concerns/AsCommand.php
+++ b/src/Concerns/AsCommand.php
@@ -2,6 +2,22 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+/**
+ * @property-read  string $commandSignature
+ * @method string getCommandSignature()
+ *
+ * @property-read  string $commandName
+ * @method string getCommandName()
+ *
+ * @property-read  string $commandDescription
+ * @method string getCommandDescription()
+ *
+ * @property-read  string $commandHelp
+ * @method string getCommandHelp()
+ *
+ * @property-read  bool $commandHidden
+ * @method bool isCommandHidden()
+ */
 trait AsCommand
 {
     //

--- a/src/Concerns/AsController.php
+++ b/src/Concerns/AsController.php
@@ -2,6 +2,13 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+/**
+ * @method array getControllerMiddleware()
+ * @method \Illuminate\Http\Resources\Json\JsonResource jsonResponse()
+ * @method \Illuminate\Http\Response htmlResponse()
+ * @method void routes(\Illuminate\Routing\Router $router)
+ * @method \Illuminate\Http\Response asController()
+  */
 trait AsController
 {
     /**

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -13,7 +13,39 @@ use Lorisleiva\Actions\ActionPendingChain;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Throwable;
 
+/**
+ * @property-read string $jobConnection
+ * @property-read string $jobQueue
+ * @property-read int $jobTries
+ * @property-read int $jobMaxExceptions
+ * @property-read int $jobTimeout
+ * @method void configureJob(JobDecorator|UniqueJobDecorator $job)
+ *
+ * @property-read int|array $jobBackoff
+ * @method int|array getJobBackoff(...$parameters)
+ *
+ * @property-read \DateTime|int $jobRetryUntil
+ * @method \DateTime|int getJobRetryUntil(...$parameters)
+ *
+ * @method array getJobMiddleware(...$parameters)
+ *
+ * @method void jobFailed(Throwable $e, ...$parameters)
+ *
+ * @method string getJobDisplayName(...$parameters)
+ *
+ * @method array getJobTags(...$parameters)
+ *
+ * @property-read int $jobUniqueFor
+ * @method int getJobUniqueFor(...$parameters)
+ *
+ * @property-read int $jobUniqueId
+ * @method int getJobUniqueId(...$parameters)
+ *
+ * @method int getJobUniqueVia(...$parameters)
+ *
+ */
 trait AsJob
 {
     /**

--- a/src/Concerns/AsListener.php
+++ b/src/Concerns/AsListener.php
@@ -2,6 +2,10 @@
 
 namespace Lorisleiva\Actions\Concerns;
 
+/**
+ * @method void asListener()
+ * @method bool shouldQueue()
+ */
 trait AsListener
 {
     //

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -6,6 +6,21 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Lorisleiva\Actions\AttributeValidator;
 
+/**
+ * @method void prepareForValidation(\Lorisleiva\Actions\ActionRequest $request)
+ * @method bool|\Illuminate\Auth\Access\Response authorize(\Lorisleiva\Actions\ActionRequest $request)
+ * @method array rules()
+ * @method void withValidator(\Illuminate\Validation\Validator $validator, \Lorisleiva\Actions\ActionRequest $request)
+ * @method void afterValidator(\Illuminate\Validation\Validator $validator, \Lorisleiva\Actions\ActionRequest $request)
+ * @method \Illuminate\Validation\Validator getValidator(\Illuminate\Validation\Factory $factory, \Lorisleiva\Actions\ActionRequest $request)
+ * @method array getValidationData(\Lorisleiva\Actions\ActionRequest $request)
+ * @method array getValidationMessages()
+ * @method array getValidationAttributes()
+ * @method string getValidationRedirect(\Illuminate\Routing\UrlGenerator $url)
+ * @method string getValidationErrorBag()
+ * @method void getValidationFailure()
+ * @method void getAuthorizationFailure()
+ */
 trait WithAttributes
 {
     protected array $attributes = [];


### PR DESCRIPTION
This PR adds docBlocks to several Laravel Actions traits. The docBlocks are intended to help provide better autocompletion when using a PHP IDE. Created for use with PhpStorm, but I suspect it will help users of other IDEs as well.

This PR has no code-changes. The only changes is within comments (docBlocks).