### PR TITLE
Support Laravel 11

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -18,6 +18,6 @@ jobs:
           args: --config=.php_cs.dist.php --allow-risky=yes
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Fix styling

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,19 +9,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: ["8.0", "8.1", "8.2"]
-        laravel: ["^9.0", "^10.0"]
+        php: ["8.1", "8.2", "8.3"]
+        laravel: ["^10.0", "^11.0"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: "^9.0"
-            testbench: "^7.0"
           - laravel: "^10.0"
             testbench: "^8.0"
+          - laravel: "^11.0"
+            testbench: "^9.0"
         exclude:
-          - php: "8.2"
-            laravel: "^9.0"
-          - php: "8.0"
+          - php: "8.3"
             laravel: "^10.0"
+          - php: "8.1"
+            laravel: "^11.0"
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea
 .php_cs
 .php_cs.cache
-.phpunit.result.cache
+.phpunit*
 build
 composer.lock
 coverage

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0 || ^11.0",
-        "lorisleiva/lody": "dev-l11-compatibility"
+        "illuminate/contracts": "^10.0|^11.0",
+        "lorisleiva/lody": "^0.5"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.5",
-        "pestphp/pest": "^1.23 || ^2.0",
-        "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0"
+        "orchestra/testbench": "^9.0",
+        "pestphp/pest": "^1.23|^2.34",
+        "phpunit/phpunit": "^9.6|^10.0"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/contracts": "9.0 - 9.34 || ^9.36 || ^10.0",
+        "php": "^8.1",
+        "illuminate/contracts": "^10.0 || ^11.0",
         "lorisleiva/lody": "^0.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,19 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0 || ^11.0",
-        "lorisleiva/lody": "^0.4"
+        "lorisleiva/lody": "dev-l11-compatibility"
     },
     "require-dev": {
         "orchestra/testbench": "^8.5",
         "pestphp/pest": "^1.23",
         "phpunit/phpunit": "^9.6"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/laravel-shift/lody.git"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Lorisleiva\\Actions\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,6 @@
         "pestphp/pest": "^1.23|^2.34",
         "phpunit/phpunit": "^9.6|^10.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/laravel-shift/lody.git"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "Lorisleiva\\Actions\\": "src"

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "^8.5",
-        "pestphp/pest": "^1.23",
-        "phpunit/phpunit": "^9.6"
+        "pestphp/pest": "^1.23 || ^2.0",
+        "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0"
     },
     "repositories": [
         {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,36 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="DB_CONNECTION" value="sqlite"/>
+    <env name="DB_DATABASE" value=":memory:"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/AsJobWithBatchTest.php
+++ b/tests/AsJobWithBatchTest.php
@@ -5,6 +5,7 @@ namespace Lorisleiva\Actions\Tests;
 use Illuminate\Bus\Batch;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Lorisleiva\Actions\Concerns\AsJob;
 
 class AsJobWithBatchTest
@@ -43,8 +44,12 @@ beforeEach(function () {
 
     // And have a `job_batches` table.
     $this->artisan('migrate')->run();
-    if (! Schema::hasTable('job_batches')) {
-        $this->artisan('queue:batches-table')->run();
+    if (!Schema::hasTable('job_batches')) {
+        if (Str::startsWith($this->app->version(), "11.")) {
+            $this->artisan('make:queue-batches-table')->run();
+        } else {
+            $this->artisan('queue:batches-table')->run();
+        }
         $this->artisan('migrate')->run();
     }
 });

--- a/tests/AsJobWithBatchTest.php
+++ b/tests/AsJobWithBatchTest.php
@@ -44,7 +44,7 @@ beforeEach(function () {
 
     // And have a `job_batches` table.
     $this->artisan('migrate')->run();
-    if (!Schema::hasTable('job_batches')) {
+    if (! Schema::hasTable('job_batches')) {
         if (Str::startsWith($this->app->version(), "11.")) {
             $this->artisan('make:queue-batches-table')->run();
         } else {


### PR DESCRIPTION
Only support two latest major versions of Laravel as per Support Policy https://laravel.com/docs/11.x/releases#support-policy

Remove Laravel 9 and PHP 8.0 support