### PR TITLE
Handle $deleteWhenMissingModels on JobDecorator

### DIFF
--- a/src/Decorators/JobDecorator.php
+++ b/src/Decorators/JobDecorator.php
@@ -180,11 +180,11 @@ class JobDecorator implements ShouldQueue
 
         if ($firstParameter->allowsNull() && $firstParameterClass === Batch::class) {
             return [$this->batch(), ...$this->parameters];
-        } elseif (is_subclass_of($firstParameterClass, self::class) || $firstParameterClass === self::class) {
-            return [$this, ...$this->parameters];
-        } else {
-            return $this->parameters;
         }
+        if (is_subclass_of($firstParameterClass, self::class) || $firstParameterClass === self::class) {
+            return [$this, ...$this->parameters];
+        }
+        return $this->parameters;
     }
 
     protected function serializeProperties()

--- a/src/Decorators/JobDecorator.php
+++ b/src/Decorators/JobDecorator.php
@@ -194,6 +194,7 @@ class JobDecorator implements ShouldQueue
         if (is_subclass_of($firstParameterClass, self::class) || $firstParameterClass === self::class) {
             return [$this, ...$this->parameters];
         }
+
         return $this->parameters;
     }
 

--- a/src/Decorators/JobDecorator.php
+++ b/src/Decorators/JobDecorator.php
@@ -33,6 +33,8 @@ class JobDecorator implements ShouldQueue
     protected string $actionClass;
     protected array $parameters = [];
 
+    public ?bool $deleteWhenMissingModels;
+
     public function __construct(string $action, ...$parameters)
     {
         $this->actionClass = $action;
@@ -48,6 +50,7 @@ class JobDecorator implements ShouldQueue
         $this->setTries($this->fromActionProperty('jobTries'));
         $this->setMaxExceptions($this->fromActionProperty('jobMaxExceptions'));
         $this->setTimeout($this->fromActionProperty('jobTimeout'));
+        $this->setDeleteWhenMissingModels($this->fromActionProperty('jobDeleteWhenMissingModels'));
         $this->fromActionMethod('configureJob', [$this]);
     }
 
@@ -101,6 +104,13 @@ class JobDecorator implements ShouldQueue
     public function setTimeout(?int $timeout)
     {
         $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    public function setDeleteWhenMissingModels(?bool $deleteWhenMissingModels)
+    {
+        $this->deleteWhenMissingModels = $deleteWhenMissingModels;
 
         return $this;
     }

--- a/tests/AsJobConfiguredWithMethodsTest.php
+++ b/tests/AsJobConfiguredWithMethodsTest.php
@@ -18,7 +18,8 @@ class AsJobConfiguredWithMethodsTest
             ->onQueue('my_queue')
             ->through(['my_middleware'])
             ->chain(['my_chain'])
-            ->delay(60);
+            ->delay(60)
+            ->setDeleteWhenMissingModels(true);
     }
 
     public function getJobBackoff(): array
@@ -56,6 +57,7 @@ it('uses the configuration provided in the configureJob and getJobX methods', fu
             && $job->middleware === ['my_middleware']
             && $job->chained === [serialize('my_chain')]
             && $job->delay === 60
+            && $job->deleteWhenMissingModels === true
             && $job->backoff() === [30, 60, 120]
             && $job->retryUntil()->timestamp === now()->addMinutes(30)->timestamp;
     });

--- a/tests/AsJobConfiguredWithPropertiesTest.php
+++ b/tests/AsJobConfiguredWithPropertiesTest.php
@@ -17,6 +17,7 @@ class AsJobConfiguredWithPropertiesTest
     public int $jobBackoff = 60 * 5;
     public int $jobTimeout = 60 * 30;
     public int $jobRetryUntil = 3600 * 2;
+    public bool $jobDeleteWhenMissingModels = true;
 
     public function handle()
     {
@@ -41,6 +42,7 @@ it('uses the configuration provided in properties', function () {
             && $job->maxExceptions === 3
             && $job->backoff() === 60 * 5
             && $job->timeout === 60 * 30
+            && $job->deleteWhenMissingModels === true
             && $job->retryUntil() === 3600 * 2;
     });
 });


### PR DESCRIPTION

This enables the user to configure the job using `->setDeleteWhenMissingModels()` within `configureJob()` or by setting `$jobDeleteWhenMissingModels = true`