### PR TITLE
Fix Orchestra Laravel 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "controller",
         "job",
         "object",
-        "command"
+        "command",
+        "listener"
     ],
     "homepage": "https://github.com/lorisleiva/laravel-actions",
     "license": "MIT",
@@ -26,7 +27,7 @@
         "lorisleiva/lody": "^0.5"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^1.23|^2.34",
         "phpunit/phpunit": "^9.6|^10.0"
     },


### PR DESCRIPTION
When you run PHP 8.1, and you try `composer install` the following error will appear:

![Screenshot 2024-08-09 at 22 54 32](https://github.com/user-attachments/assets/11d0f330-1579-4b82-ba36-ea713331cb70)
Laravel 10 [needs](https://packages.tools/testbench#version-compatibility) Orchestra Testbench 8.

This PR fixes that compatibility.

The branch name is not entirely correct, but you get the point. 😋

👋 Edwin