### PR TITLE
Cleanup docblocks added return types

### DIFF
--- a/src/ActionPendingChain.php
+++ b/src/ActionPendingChain.php
@@ -3,11 +3,12 @@
 namespace Lorisleiva\Actions;
 
 use Illuminate\Foundation\Bus\PendingChain;
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Lorisleiva\Actions\Concerns\AsJob;
 
 class ActionPendingChain extends PendingChain
 {
-    public function dispatch()
+    public function dispatch(): ?PendingDispatch
     {
         /** @var $job AsJob */
         if ($this->usesAsJobTrait($job = $this->job)) {
@@ -17,7 +18,7 @@ class ActionPendingChain extends PendingChain
         return parent::dispatch();
     }
 
-    public function usesAsJobTrait($job)
+    public function usesAsJobTrait($job): bool
     {
         return is_string($job)
             && class_exists($job)

--- a/src/ActionRequest.php
+++ b/src/ActionRequest.php
@@ -9,7 +9,7 @@ class ActionRequest extends FormRequest
 {
     use ValidateActions;
 
-    public function validateResolved()
+    public function validateResolved(): void
     {
         // Cancel the auto-resolution trait.
     }

--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -11,7 +11,10 @@ use Lorisleiva\Actions\DesignPatterns\ListenerDesignPattern;
 
 class ActionServiceProvider extends ServiceProvider
 {
-    public function register()
+    /**
+     * Register any application services.
+     */
+    public function register(): void
     {
         $this->app->scoped(ActionManager::class, function () {
             return new ActionManager([
@@ -24,10 +27,13 @@ class ActionServiceProvider extends ServiceProvider
         $this->extendActions();
     }
 
-    public function boot()
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
-            // publish Stubs File
+            // Publish Stubs File
             $this->publishes([
                 __DIR__ . '/Console/stubs/action.stub' => base_path('stubs/action.stub'),
             ], 'stubs');
@@ -39,7 +45,7 @@ class ActionServiceProvider extends ServiceProvider
         }
     }
 
-    protected function extendActions()
+    protected function extendActions(): void
     {
         $this->app->beforeResolving(function ($abstract, $parameters, Application $app) {
             if ($abstract === ActionManager::class) {
@@ -50,7 +56,7 @@ class ActionServiceProvider extends ServiceProvider
                 // Fix conflict with package: barryvdh/laravel-ide-helper.
                 // @see https://github.com/lorisleiva/laravel-actions/issues/142
                 $classExists = class_exists($abstract);
-            } catch (\ReflectionException $exception) {
+            } catch (\ReflectionException) {
                 return;
             }
 

--- a/src/BacktraceFrame.php
+++ b/src/BacktraceFrame.php
@@ -9,9 +9,7 @@ class BacktraceFrame
     public ?string $class;
     public ?string $function;
     public bool $isStatic;
-
-    /** @var mixed|null */
-    public $object;
+    public mixed $object;
 
     public function __construct(array $frame)
     {
@@ -36,9 +34,9 @@ class BacktraceFrame
             || is_subclass_of($this->class, $superClass);
     }
 
-    public function matches(string $class, string $method, ?bool $isStatic = null)
+    public function matches(string $class, string $method, ?bool $isStatic = null): bool
     {
-        $matchesStatic = is_null($isStatic) ? true : ($this->isStatic === $isStatic);
+        $matchesStatic = is_null($isStatic) || $this->isStatic === $isStatic;
 
         return $this->instanceOf($class)
             && $this->function === $method

--- a/src/Concerns/AsController.php
+++ b/src/Concerns/AsController.php
@@ -13,10 +13,8 @@ trait AsController
 {
     /**
      * @see static::handle()
-     * @param mixed ...$arguments
-     * @return mixed
      */
-    public function __invoke(...$arguments)
+    public function __invoke(mixed ...$arguments): mixed
     {
         return $this->handle(...$arguments);
     }
@@ -24,9 +22,8 @@ trait AsController
     /**
      * This empty method is required to enable controller middleware on the action.
      * @see https://github.com/lorisleiva/laravel-actions/issues/199
-     * @return array
      */
-    public function getMiddleware()
+    public function getMiddleware(): array
     {
         return [];
     }

--- a/src/Concerns/AsFake.php
+++ b/src/Concerns/AsFake.php
@@ -10,9 +10,6 @@ use Mockery\MockInterface;
 
 trait AsFake
 {
-    /**
-     * @return MockInterface
-     */
     public static function mock(): MockInterface
     {
         if (static::isFake()) {
@@ -25,9 +22,6 @@ trait AsFake
         return static::setFakeResolvedInstance($mock);
     }
 
-    /**
-     * @return MockInterface
-     */
     public static function spy(): MockInterface
     {
         if (static::isFake()) {
@@ -37,41 +31,26 @@ trait AsFake
         return static::setFakeResolvedInstance(Mockery::spy(static::class));
     }
 
-    /**
-     * @return MockInterface
-     */
     public static function partialMock(): MockInterface
     {
         return static::mock()->makePartial();
     }
 
-    /**
-     * @return Expectation|ExpectationInterface|HigherOrderMessage
-     */
-    public static function shouldRun()
+    public static function shouldRun(): Expectation|ExpectationInterface|HigherOrderMessage
     {
         return static::mock()->shouldReceive('handle');
     }
 
-    /**
-     * @return Expectation|ExpectationInterface|HigherOrderMessage
-     */
-    public static function shouldNotRun()
+    public static function shouldNotRun(): Expectation|ExpectationInterface|HigherOrderMessage
     {
         return static::mock()->shouldNotReceive('handle');
     }
 
-    /**
-     * @return Expectation|ExpectationInterface|HigherOrderMessage|MockInterface
-     */
-    public static function allowToRun()
+    public static function allowToRun(): Expectation|ExpectationInterface|HigherOrderMessage|MockInterface
     {
         return static::spy()->allows('handle');
     }
 
-    /**
-     * @return bool
-     */
     public static function isFake(): bool
     {
         return app()->isShared(static::getFakeResolvedInstanceKey());
@@ -85,26 +64,16 @@ trait AsFake
         app()->forgetInstance(static::getFakeResolvedInstanceKey());
     }
 
-    /**
-     * @param MockInterface $fake
-     * @return MockInterface
-     */
     protected static function setFakeResolvedInstance(MockInterface $fake): MockInterface
     {
         return app()->instance(static::getFakeResolvedInstanceKey(), $fake);
     }
 
-    /**
-     * @return MockInterface|null
-     */
     protected static function getFakeResolvedInstance(): ?MockInterface
     {
         return app(static::getFakeResolvedInstanceKey());
     }
 
-    /**
-     * @return string
-     */
     protected static function getFakeResolvedInstanceKey(): string
     {
         return 'LaravelActions:AsFake:' . static::class;

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -24,35 +24,34 @@ use Throwable;
  * @method void configureJob(JobDecorator|UniqueJobDecorator $job)
  *
  * @property-read int|array $jobBackoff
- * @method int|array getJobBackoff(...$parameters)
+ * @method int|array getJobBackoff()
  *
  * @property-read \DateTime|int $jobRetryUntil
- * @method \DateTime|int getJobRetryUntil(...$parameters)
+ * @method \DateTime|int getJobRetryUntil()
  *
- * @method array getJobMiddleware(...$parameters)
+ * @method array getJobMiddleware()
  *
- * @method void jobFailed(Throwable $e, ...$parameters)
+ * @method void jobFailed(Throwable $e)
  *
- * @method string getJobDisplayName(...$parameters)
+ * @method string getJobDisplayName()
  *
- * @method array getJobTags(...$parameters)
+ * @method array getJobTags()
  *
  * @property-read int $jobUniqueFor
- * @method int getJobUniqueFor(...$parameters)
+ * @method int getJobUniqueFor()
  *
  * @property-read int $jobUniqueId
- * @method int getJobUniqueId(...$parameters)
+ * @method int getJobUniqueId()
  *
- * @method int getJobUniqueVia(...$parameters)
+ * @method int getJobUniqueVia()
+ *
+ * @property-read bool $jobDeleteWhenMissingModels
+ * @method bool getJobDeleteWhenMissingModels()
  *
  */
 trait AsJob
 {
-    /**
-     * @param mixed ...$arguments
-     * @return JobDecorator|UniqueJobDecorator
-     */
-    public static function makeJob(...$arguments): JobDecorator
+    public static function makeJob(mixed ...$arguments): JobDecorator
     {
         if (static::jobShouldBeUnique()) {
             return static::makeUniqueJob(...$arguments);
@@ -61,93 +60,52 @@ trait AsJob
         return new ActionManager::$jobDecorator(static::class, ...$arguments);
     }
 
-    /**
-     * @param mixed ...$arguments
-     * @return UniqueJobDecorator
-     */
-    public static function makeUniqueJob(...$arguments): UniqueJobDecorator
+    public static function makeUniqueJob(mixed ...$arguments): UniqueJobDecorator
     {
         return new ActionManager::$uniqueJobDecorator(static::class, ...$arguments);
     }
 
-    /**
-     * @return bool
-     */
     protected static function jobShouldBeUnique(): bool
     {
         return is_subclass_of(static::class, ShouldBeUnique::class);
     }
 
-    /**
-     * @param mixed ...$arguments
-     * @return PendingDispatch
-     */
-    public static function dispatch(...$arguments): PendingDispatch
+    public static function dispatch(mixed ...$arguments): PendingDispatch
     {
         return new PendingDispatch(static::makeJob(...$arguments));
     }
 
-    /**
-     * @param $boolean
-     * @param mixed ...$arguments
-     * @return PendingDispatch|Fluent
-     */
-    public static function dispatchIf($boolean, ...$arguments)
+    public static function dispatchIf(bool $boolean, mixed ...$arguments): PendingDispatch|Fluent
     {
         return $boolean ? static::dispatch(...$arguments) : new Fluent;
     }
 
-    /**
-     * @param $boolean
-     * @param mixed ...$arguments
-     * @return PendingDispatch|Fluent
-     */
-    public static function dispatchUnless($boolean, ...$arguments)
+    public static function dispatchUnless(bool $boolean, mixed ...$arguments): PendingDispatch|Fluent
     {
         return static::dispatchIf(! $boolean, ...$arguments);
     }
 
-    /**
-     * @param mixed ...$arguments
-     * @return mixed
-     */
-    public static function dispatchSync(...$arguments)
+    public static function dispatchSync(mixed ...$arguments): mixed
     {
         return app(Dispatcher::class)->dispatchSync(static::makeJob(...$arguments));
     }
 
-    /**
-     * @param mixed ...$arguments
-     * @return mixed
-     */
-    public static function dispatchNow(...$arguments)
+    public static function dispatchNow(mixed ...$arguments): mixed
     {
         return static::dispatchSync(...$arguments);
     }
 
-    /**
-     * @param mixed ...$arguments
-     * @return void
-     */
-    public static function dispatchAfterResponse(...$arguments): void
+    public static function dispatchAfterResponse(mixed ...$arguments): void
     {
         static::dispatch(...$arguments)->afterResponse();
     }
 
-    /**
-     * @param $chain
-     * @return ActionPendingChain
-     */
-    public static function withChain($chain): ActionPendingChain
+    public static function withChain(array $chain): ActionPendingChain
     {
         return new ActionPendingChain(static::class, $chain);
     }
 
-    /**
-     * @param Closure|int|null $times
-     * @param Closure|null $callback
-     */
-    public static function assertPushed($times = null, Closure $callback = null): void
+    public static function assertPushed(Closure|int|null $times = null, Closure|null $callback = null): void
     {
         if ($times instanceof Closure) {
             $callback = $times;
@@ -191,20 +149,12 @@ trait AsJob
         }
     }
 
-    /**
-     * @param Closure|null $callback
-     */
-    public static function assertNotPushed(Closure $callback = null): void
+    public static function assertNotPushed(Closure|null $callback = null): void
     {
         static::assertPushed(0, $callback);
     }
 
-    /**
-     * @param string $queue
-     * @param Closure|int|null $times
-     * @param Closure|null $callback
-     */
-    public static function assertPushedOn(string $queue, $times = null, Closure $callback = null): void
+    public static function assertPushedOn(string $queue, Closure|int|null $times = null, Closure|null $callback = null): void
     {
         if ($times instanceof Closure) {
             $callback = $times;

--- a/src/Concerns/AsObject.php
+++ b/src/Concerns/AsObject.php
@@ -6,40 +6,25 @@ use Illuminate\Support\Fluent;
 
 trait AsObject
 {
-    /**
-     * @return static
-     */
-    public static function make()
+    public static function make(): static
     {
         return app(static::class);
     }
 
     /**
      * @see static::handle()
-     * @param mixed ...$arguments
-     * @return mixed
      */
-    public static function run(...$arguments)
+    public static function run(mixed ...$arguments): mixed
     {
         return static::make()->handle(...$arguments);
     }
 
-    /**
-     * @param $boolean
-     * @param ...$arguments
-     * @return mixed|\Illuminate\Support\Fluent
-     */
-    public static function runIf($boolean, ...$arguments)
+    public static function runIf(bool $boolean, mixed ...$arguments): mixed
     {
         return $boolean ? static::run(...$arguments) : new Fluent;
     }
 
-    /**
-     * @param $boolean
-     * @param ...$arguments
-     * @return mixed|\Illuminate\Support\Fluent
-     */
-    public static function runUnless($boolean, ...$arguments)
+    public static function runUnless(bool $boolean, mixed ...$arguments): mixed
     {
         return static::runIf(! $boolean, ...$arguments);
     }

--- a/src/Concerns/DecorateActions.php
+++ b/src/Concerns/DecorateActions.php
@@ -4,8 +4,7 @@ namespace Lorisleiva\Actions\Concerns;
 
 trait DecorateActions
 {
-    /** @var mixed */
-    protected $action;
+    protected mixed $action;
 
     public function setAction($action): self
     {

--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -14,12 +14,15 @@ trait ValidateActions
     use DecorateActions;
 
     /** @var Validator|null */
-    protected $validator = null;
+    protected $validator;
 
     /** @var Redirector|null */
-    protected $redirector = null;
+    protected $redirector;
 
-    public function validate()
+    /**
+     * @throws ValidationException
+     */
+    public function validate(): void
     {
         $this->prepareForValidation();
         $response = $this->inspectAuthorization();

--- a/src/Concerns/WithAttributes.php
+++ b/src/Concerns/WithAttributes.php
@@ -25,33 +25,21 @@ trait WithAttributes
 {
     protected array $attributes = [];
 
-    /**
-     * @param array $attributes
-     * @return static
-     */
-    public function setRawAttributes(array $attributes): self
+    public function setRawAttributes(array $attributes): static
     {
         $this->attributes = $attributes;
 
         return $this;
     }
 
-    /**
-     * @param array $attributes
-     * @return static
-     */
-    public function fill(array $attributes): self
+    public function fill(array $attributes): static
     {
         $this->attributes = array_merge($this->attributes, $attributes);
 
         return $this;
     }
 
-    /**
-     * @param Request $request
-     * @return static
-     */
-    public function fillFromRequest(Request $request): self
+    public function fillFromRequest(Request $request): static
     {
         $route = $request->route();
 
@@ -89,12 +77,7 @@ trait WithAttributes
         return Arr::get($this->attributes, $key, $default);
     }
 
-    /**
-     * @param string $key
-     * @param mixed $value
-     * @return static
-     */
-    public function set(string $key, $value): self
+    public function set(string $key, mixed $value): static
     {
         Arr::set($this->attributes, $key, $value);
 

--- a/src/Console/MakeActionCommand.php
+++ b/src/Console/MakeActionCommand.php
@@ -15,25 +15,28 @@ class MakeActionCommand extends GeneratorCommand
 
     protected $type = 'Action';
 
-    protected function getStub()
+    /**
+     * Get the stub file for the generator.
+     */
+    protected function getStub(): string
     {
         return $this->resolveStubPath('/stubs/action.stub');
     }
 
     /**
      * Resolve the fully-qualified path to the stub.
-     *
-     * @param string $stub
-     * @return string
      */
-    protected function resolveStubPath($stub)
+    protected function resolveStubPath(string $stub): string
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
             : __DIR__ . $stub;
     }
 
-    protected function getDefaultNamespace($rootNamespace)
+    /**
+     * Get the default namespace for the class.
+     */
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace.'\Actions';
     }

--- a/src/Decorators/CommandDecorator.php
+++ b/src/Decorators/CommandDecorator.php
@@ -2,8 +2,8 @@
 
 namespace Lorisleiva\Actions\Decorators;
 
-use \Illuminate\Console\View\Components\Factory;
 use Illuminate\Console\Command;
+use Illuminate\Console\View\Components\Factory;
 use Lorisleiva\Actions\Concerns\DecorateActions;
 use Lorisleiva\Actions\Exceptions\MissingCommandSignatureException;
 
@@ -39,7 +39,7 @@ class CommandDecorator extends Command
         }
     }
 
-    public function getComponents():Factory
+    public function getComponents(): Factory
     {
         return $this->components;
     }

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -15,16 +15,12 @@ class ControllerDecorator
     use RouteDependencyResolverTrait;
     use DecorateActions;
 
-    /** @var Container */
     protected Container $container;
 
-    /** @var Route */
     protected Route $route;
 
-    /** @var array */
-    protected $middleware = [];
+    protected array $middleware = [];
 
-    /** @var bool */
     protected bool $executedAtLeastOne = false;
 
     public function __construct($action, Route $route)

--- a/src/Decorators/JobDecorator.php
+++ b/src/Decorators/JobDecorator.php
@@ -29,11 +29,10 @@ class JobDecorator implements ShouldQueue
     public ?int $tries;
     public ?int $maxExceptions;
     public ?int $timeout;
+    public ?bool $deleteWhenMissingModels;
 
     protected string $actionClass;
     protected array $parameters = [];
-
-    public ?bool $deleteWhenMissingModels;
 
     public function __construct(string $action, ...$parameters)
     {
@@ -43,7 +42,7 @@ class JobDecorator implements ShouldQueue
         $this->constructed();
     }
 
-    protected function constructed()
+    protected function constructed(): void
     {
         $this->onConnection($this->fromActionProperty('jobConnection'));
         $this->onQueue($this->fromActionProperty('jobQueue'));
@@ -75,40 +74,28 @@ class JobDecorator implements ShouldQueue
         return $this->parameters;
     }
 
-    /**
-     * @param int|null $tries
-     * @return $this
-     */
-    public function setTries(?int $tries)
+    public function setTries(?int $tries): self
     {
         $this->tries = $tries;
 
         return $this;
     }
 
-    /**
-     * @param int|null $maxException
-     * @return $this
-     */
-    public function setMaxExceptions(?int $maxException)
+    public function setMaxExceptions(?int $maxException): self
     {
         $this->maxExceptions = $maxException;
 
         return $this;
     }
 
-    /**
-     * @param int|null $timeout
-     * @return $this
-     */
-    public function setTimeout(?int $timeout)
+    public function setTimeout(?int $timeout): self
     {
         $this->timeout = $timeout;
 
         return $this;
     }
 
-    public function setDeleteWhenMissingModels(?bool $deleteWhenMissingModels)
+    public function setDeleteWhenMissingModels(?bool $deleteWhenMissingModels): self
     {
         $this->deleteWhenMissingModels = $deleteWhenMissingModels;
 
@@ -149,11 +136,8 @@ class JobDecorator implements ShouldQueue
      * Laravel will call failed() on a job that fails. This function will call
      * the function jobFailed(Throwable $e) on the underlying action if Laravel
      * calls the failed() function on the job.
-     *
-     * @param Throwable $e
-     * @return void
      */
-    public function failed(Throwable $e)
+    public function failed(Throwable $e): void
     {
         $this->fromActionMethod('jobFailed', [$e, ...$this->parameters], []);
     }
@@ -198,7 +182,7 @@ class JobDecorator implements ShouldQueue
         return $this->parameters;
     }
 
-    protected function serializeProperties()
+    protected function serializeProperties(): void
     {
         $this->action = $this->actionClass;
 
@@ -207,7 +191,7 @@ class JobDecorator implements ShouldQueue
         });
     }
 
-    protected function unserializeProperties()
+    protected function unserializeProperties(): void
     {
         $this->setAction(app($this->actionClass));
 
@@ -216,14 +200,14 @@ class JobDecorator implements ShouldQueue
         });
     }
 
-    public function __serialize()
+    public function __serialize(): array
     {
         $this->serializeProperties();
 
         return $this->serializeFromSerializesModels();
     }
 
-    public function __unserialize(array $values)
+    public function __unserialize(array $values): void
     {
         $this->unserializeFromSerializesModels($values);
         $this->unserializeProperties();

--- a/src/Decorators/UniqueJobDecorator.php
+++ b/src/Decorators/UniqueJobDecorator.php
@@ -10,14 +10,14 @@ class UniqueJobDecorator extends JobDecorator implements ShouldBeUnique
 {
     public int $uniqueFor = 0;
 
-    protected function constructed()
+    protected function constructed(): void
     {
         $this->uniqueFor = (int) $this->fromActionWithParameters('getJobUniqueFor', 'jobUniqueFor', 0);
 
         parent::constructed();
     }
 
-    public function uniqueId()
+    public function uniqueId(): string
     {
         $uniqueId = $this->fromActionWithParameters('getJobUniqueId', 'jobUniqueId', '');
         $prefix = '.' . get_class($this->action);

--- a/src/Facades/Actions.php
+++ b/src/Facades/Actions.php
@@ -12,7 +12,10 @@ use Lorisleiva\Actions\ActionManager;
  */
 class Actions extends Facade
 {
-    protected static function getFacadeAccessor()
+    /**
+     * Get the registered name of the component.
+     */
+    protected static function getFacadeAccessor(): string
     {
         return ActionManager::class;
     }

--- a/tests/AsActionTest.php
+++ b/tests/AsActionTest.php
@@ -27,18 +27,14 @@ class AsActionTest
 
     protected function getStrategyFromOperation(string $operation): Closure
     {
-        switch ($operation) {
-            case 'substraction':
-                return fn (int $left, int $right) => $left - $right;
-            case 'multiplication':
-                return fn (int $left, int $right) => $left * $right;
-            case 'addition':
-            default:
-                return fn (int $left, int $right) => $left + $right;
-        }
+        return match ($operation) {
+            'substraction' => fn (int $left, int $right) => $left - $right,
+            'multiplication' => fn (int $left, int $right) => $left * $right,
+            default => fn (int $left, int $right) => $left + $right,
+        };
     }
 
-    public function asController(ActionRequest $request)
+    public function asController(ActionRequest $request): array
     {
         $result = $this->handle(
             $request->route('operation'),
@@ -54,7 +50,7 @@ class AsActionTest
         return $this->handle($operation, $left, $right);
     }
 
-    public function asListener(OperationRequestedEvent $event)
+    public function asListener(OperationRequestedEvent $event): int
     {
         return $this->handle(
             $event->operation,
@@ -63,7 +59,7 @@ class AsActionTest
         );
     }
 
-    public function asCommand(Command $command)
+    public function asCommand(Command $command): void
     {
         $result = $this->handle(
             $command->argument('operation'),

--- a/tests/AsActionWithValidatedAttributesTest.php
+++ b/tests/AsActionWithValidatedAttributesTest.php
@@ -44,15 +44,11 @@ class AsActionWithValidatedAttributesTest
 
     protected function applyStrategyFromOperation(): int
     {
-        switch ($this->operation) {
-            case 'substraction':
-                return $this->left - $this->right;
-            case 'multiplication':
-                return $this->left * $this->right;
-            case 'addition':
-            default:
-                return $this->left + $this->right;
-        }
+        return match ($this->operation) {
+            'substraction' => $this->left - $this->right,
+            'multiplication' => $this->left * $this->right,
+            default => $this->left + $this->right,
+        };
     }
 
     public function asController(ActionRequest $request): array

--- a/tests/AsCommandInSchedulerTest.php
+++ b/tests/AsCommandInSchedulerTest.php
@@ -12,7 +12,7 @@ class AsCommandInSchedulerTest
 
     public string $commandSignature = 'my:command';
 
-    public function handle()
+    public function handle(): void
     {
         // ...
     }

--- a/tests/AsCommandTest.php
+++ b/tests/AsCommandTest.php
@@ -11,7 +11,7 @@ class AsCommandTest
 
     public static ?CommandDecorator $decorator;
 
-    public function handle(CommandDecorator $command)
+    public function handle(CommandDecorator $command): void
     {
         static::$decorator = $command;
 

--- a/tests/AsCommandUsingPropertiesTest.php
+++ b/tests/AsCommandUsingPropertiesTest.php
@@ -16,7 +16,7 @@ class AsCommandUsingPropertiesTest
     public string $commandHelp = 'My command help.';
     public bool $commandHidden = true;
 
-    public function handle(CommandDecorator $command)
+    public function handle(CommandDecorator $command): void
     {
         static::$decorator = $command;
 

--- a/tests/AsCommandWithoutSignatureTest.php
+++ b/tests/AsCommandWithoutSignatureTest.php
@@ -9,7 +9,7 @@ class AsCommandWithoutSignatureTest
 {
     use AsCommand;
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/AsControllerAndObjectTest.php
+++ b/tests/AsControllerAndObjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Lorisleiva\Actions\Tests;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
 use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\AsController;
@@ -17,7 +18,7 @@ class AsControllerAndObjectTest
         return $left + $right;
     }
 
-    public function asController($left, ActionRequest $request)
+    public function asController($left, ActionRequest $request): JsonResponse
     {
         $addition = $this->handle($left, $request->get('right'));
 

--- a/tests/AsControllerTest.php
+++ b/tests/AsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Lorisleiva\Actions\Tests;
 
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
 use Lorisleiva\Actions\Concerns\AsController;
 
@@ -18,7 +19,7 @@ class AsControllerTest
         static::$constructed++;
     }
 
-    public function handle($left, $right, Filesystem $filesystem)
+    public function handle($left, $right, Filesystem $filesystem): JsonResponse
     {
         static::$handled++;
 

--- a/tests/AsControllerWithCustomFailuresTest.php
+++ b/tests/AsControllerWithCustomFailuresTest.php
@@ -10,12 +10,12 @@ class AsControllerWithCustomFailuresTest
 {
     use AsController;
 
-    public function authorize(ActionRequest $request)
+    public function authorize(ActionRequest $request): bool
     {
         return $request->get('operation') !== 'unauthorized';
     }
 
-    public function rules()
+    public function rules(): array
     {
         return [
             'left' => ['required'],
@@ -28,12 +28,12 @@ class AsControllerWithCustomFailuresTest
         return $request->left + $request->right;
     }
 
-    public function getAuthorizationFailure()
+    public function getAuthorizationFailure(): void
     {
         abort(400, 'Custom authorization failure.');
     }
 
-    public function getValidationFailure()
+    public function getValidationFailure(): void
     {
         abort(400, 'Custom validation failure.');
     }

--- a/tests/AsControllerWithCustomRedirectAndErrorBagTest.php
+++ b/tests/AsControllerWithCustomRedirectAndErrorBagTest.php
@@ -12,7 +12,7 @@ class AsControllerWithCustomRedirectAndErrorBagTest
 {
     use AsController;
 
-    public function rules()
+    public function rules(): array
     {
         return [
             'left' => ['required'],

--- a/tests/AsControllerWithCustomValidationDataTest.php
+++ b/tests/AsControllerWithCustomValidationDataTest.php
@@ -19,7 +19,7 @@ class AsControllerWithCustomValidationDataTest
         );
     }
 
-    public function rules()
+    public function rules(): array
     {
         return [
             'left' => ['required'],

--- a/tests/AsControllerWithJsonAndHtmlResponseTest.php
+++ b/tests/AsControllerWithJsonAndHtmlResponseTest.php
@@ -3,6 +3,7 @@
 namespace Lorisleiva\Actions\Tests;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Http\JsonResponse;
 use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\AsController;
 
@@ -15,7 +16,7 @@ class AsControllerWithJsonAndHtmlResponseTest
         return $request->left + $request->right;
     }
 
-    public function jsonResponse($result, ActionRequest $request)
+    public function jsonResponse($result, ActionRequest $request): JsonResponse
     {
         return response()->json([
             'result' => $result,

--- a/tests/AsControllerWithMiddlewareTest.php
+++ b/tests/AsControllerWithMiddlewareTest.php
@@ -13,7 +13,7 @@ class AsControllerWithMiddlewareTest
 
     public static int $middlewareCounter = 0;
 
-    public function getControllerMiddleware()
+    public function getControllerMiddleware(): array
     {
         return [
             function (Request $request, $next) {
@@ -74,7 +74,7 @@ it('calls route and controller middleware exactly once', function () {
         ->middleware(RouteMiddleware::class);
 
     // When we call that route.
-    $response = $this->postJson('/calculator');
+    $this->postJson('/calculator');
 
     // The we were intercepted by both the route and the controller middleware exactly one.
     expect(RouteMiddleware::$counter)->toBe(1);

--- a/tests/AsControllerWithPolicyResponsesTest.php
+++ b/tests/AsControllerWithPolicyResponsesTest.php
@@ -20,7 +20,7 @@ class AsControllerWithPolicyResponsesTest
         return Response::allow();
     }
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/AsControllerWithPrepareForValidationTest.php
+++ b/tests/AsControllerWithPrepareForValidationTest.php
@@ -10,7 +10,7 @@ class AsControllerWithPrepareForValidationTest
 {
     use AsController;
 
-    public function prepareForValidation(ActionRequest $request)
+    public function prepareForValidation(ActionRequest $request): void
     {
         preg_match('/^(\d+)?(.)?(\d+)?$/', $request->route('expression'), $match);
 
@@ -21,7 +21,7 @@ class AsControllerWithPrepareForValidationTest
         ]);
     }
 
-    public function rules()
+    public function rules(): array
     {
         return [
             'left' => ['required'],

--- a/tests/AsControllerWithRoutesTest.php
+++ b/tests/AsControllerWithRoutesTest.php
@@ -2,6 +2,7 @@
 
 namespace Lorisleiva\Actions\Tests;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Router;
 use Lorisleiva\Actions\Concerns\AsController;
 use Lorisleiva\Actions\Facades\Actions;
@@ -10,12 +11,12 @@ class AsControllerWithRoutesTest
 {
     use AsController;
 
-    public static function routes(Router $router)
+    public static function routes(Router $router): void
     {
         $router->get('/controller/with/routes', static::class);
     }
 
-    public function handle()
+    public function handle(): JsonResponse
     {
         return response()->json(['Ok'], 200);
     }

--- a/tests/AsControllerWithValidationMessagesTest.php
+++ b/tests/AsControllerWithValidationMessagesTest.php
@@ -10,7 +10,7 @@ class AsControllerWithValidationMessagesTest
 {
     use AsController;
 
-    public function rules()
+    public function rules(): array
     {
         return [
             'left' => ['required'],
@@ -18,14 +18,14 @@ class AsControllerWithValidationMessagesTest
         ];
     }
 
-    public function getValidationMessages()
+    public function getValidationMessages(): array
     {
         return [
             'left.required' => 'You forgot the left operand.',
         ];
     }
 
-    public function getValidationAttributes()
+    public function getValidationAttributes(): array
     {
         return [
             'right' => 'right operand',

--- a/tests/AsControllerWithValidatorCallbacksTest.php
+++ b/tests/AsControllerWithValidatorCallbacksTest.php
@@ -11,7 +11,7 @@ class AsControllerWithValidatorCallbacksTest
 {
     use AsController;
 
-    public function withValidator(Validator $validator, ActionRequest $request)
+    public function withValidator(Validator $validator, ActionRequest $request): void
     {
         $validator->after(function (Validator $validator) use ($request) {
             if ($request->left >= 42) {
@@ -20,7 +20,7 @@ class AsControllerWithValidatorCallbacksTest
         });
     }
 
-    public function afterValidator(ActionRequest $request, $validator)
+    public function afterValidator(ActionRequest $request, $validator): void
     {
         if ($request->right % 2 === 0) {
             $validator->errors()->add('right', 'Right must be odd.');

--- a/tests/AsFakeAndEverythingTest.php
+++ b/tests/AsFakeAndEverythingTest.php
@@ -27,7 +27,7 @@ class AsFakeAndEverythingTest
         return $left + $right;
     }
 
-    public function asCommand(Command $command)
+    public function asCommand(Command $command): void
     {
         $result = $this->handle(
             $command->argument('left'),

--- a/tests/AsFakeTest.php
+++ b/tests/AsFakeTest.php
@@ -24,15 +24,11 @@ class AsFakeTest
 
     protected function getStrategyFromOperation(string $operation): Closure
     {
-        switch ($operation) {
-            case 'substraction':
-                return fn (int $left, int $right) => $left - $right;
-            case 'multiplication':
-                return fn (int $left, int $right) => $left * $right;
-            case 'addition':
-            default:
-                return fn (int $left, int $right) => $left + $right;
-        }
+        return match ($operation) {
+            'substraction' => fn (int $left, int $right) => $left - $right,
+            'multiplication' => fn (int $left, int $right) => $left * $right,
+            default => fn (int $left, int $right) => $left + $right,
+        };
     }
 }
 

--- a/tests/AsJobConfiguredWithMethodsTest.php
+++ b/tests/AsJobConfiguredWithMethodsTest.php
@@ -12,7 +12,7 @@ class AsJobConfiguredWithMethodsTest
 {
     use AsJob;
 
-    public function configureJob(JobDecorator $job)
+    public function configureJob(JobDecorator $job): void
     {
         $job->onConnection('my_connection')
             ->onQueue('my_queue')
@@ -32,7 +32,7 @@ class AsJobConfiguredWithMethodsTest
         return now()->addMinutes(30);
     }
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/AsJobConfiguredWithPropertiesTest.php
+++ b/tests/AsJobConfiguredWithPropertiesTest.php
@@ -19,7 +19,7 @@ class AsJobConfiguredWithPropertiesTest
     public int $jobRetryUntil = 3600 * 2;
     public bool $jobDeleteWhenMissingModels = true;
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/AsJobSerializedTest.php
+++ b/tests/AsJobSerializedTest.php
@@ -11,7 +11,7 @@ class AsJobSerializedTest
 {
     use AsJob;
 
-    public function handle()
+    public function handle(): void
     {
         //
     }
@@ -60,7 +60,7 @@ it('serialises Eloquent models within the parameters', function () {
         ->and($firstParameter['class'])->toBe(get_class($model))
         ->and($firstParameter['id'])->toBe($model->id)
         ->and($firstParameter['relations'])->toBe([])
-        ->and($firstParameter['connection'])->toBeIn(["testing", "sqlite"]);
+        ->and($firstParameter['connection'])->toBeIn(['testing', 'sqlite']);
 });
 
 it('unserialises Eloquent models within the parameters', function () {
@@ -95,7 +95,7 @@ it('serialises Eloquent collections within the parameters', function () {
         ->and($firstParameter['class'])->toBe(get_class($modelA))
         ->and($firstParameter['id'])->toBe($collection->pluck('id')->toArray())
         ->and($firstParameter['relations'])->toBe([])
-        ->and($firstParameter['connection'])->toBeIn(["testing", "sqlite"]);
+        ->and($firstParameter['connection'])->toBeIn(['testing', 'sqlite']);
 });
 
 it('unserialises Eloquent collections within the parameters', function () {

--- a/tests/AsJobTest.php
+++ b/tests/AsJobTest.php
@@ -8,7 +8,6 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Queue;
 use Lorisleiva\Actions\Concerns\AsJob;
 use Lorisleiva\Actions\Decorators\JobDecorator;
-use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
 
 class AsJobTest
 {
@@ -22,7 +21,7 @@ class AsJobTest
         static::$constructed++;
     }
 
-    public function handle()
+    public function handle(): void
     {
         static::$handled++;
     }

--- a/tests/AsJobWithAssertionsTest.php
+++ b/tests/AsJobWithAssertionsTest.php
@@ -18,12 +18,12 @@ class AsJobWithAssertionsTest
         self::$queue = $queue;
     }
 
-    public function configureJob(JobDecorator $job)
+    public function configureJob(JobDecorator $job): void
     {
         $job->onQueue(static::$queue);
     }
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/AsJobWithBatchTest.php
+++ b/tests/AsJobWithBatchTest.php
@@ -22,13 +22,13 @@ class AsJobWithBatchTest
         static::$constructed++;
     }
 
-    public function handle(int $left, int $right)
+    public function handle(int $left, int $right): void
     {
         static::$handled++;
         static::$latestResult = $left + $right;
     }
 
-    public function asJob(?Batch $batch, int $left, int $right)
+    public function asJob(?Batch $batch, int $left, int $right): void
     {
         static::$latestBatch = $batch;
         $this->handle($left, $right);
@@ -45,7 +45,7 @@ beforeEach(function () {
     // And have a `job_batches` table.
     $this->artisan('migrate')->run();
     if (! Schema::hasTable('job_batches')) {
-        if (Str::startsWith($this->app->version(), "11.")) {
+        if (Str::startsWith($this->app->version(), '11.')) {
             $this->artisan('make:queue-batches-table')->run();
         } else {
             $this->artisan('queue:batches-table')->run();

--- a/tests/AsJobWithCustomNameAndTagsTest.php
+++ b/tests/AsJobWithCustomNameAndTagsTest.php
@@ -8,7 +8,7 @@ class AsJobWithCustomNameAndTagsTest
 {
     use AsJob;
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/AsJobWithFailureTest.php
+++ b/tests/AsJobWithFailureTest.php
@@ -19,7 +19,7 @@ class AsJobWithFailureTest
     /**
      * @throws Exception
      */
-    public function handle(bool $throwException, ?string $errorMessage = null)
+    public function handle(bool $throwException, ?string $errorMessage = null): void
     {
         static::$latestResult = 'started';
 
@@ -30,7 +30,7 @@ class AsJobWithFailureTest
         static::$latestResult = 'completed';
     }
 
-    public function jobFailed(Throwable $e, bool $throwException, string $errorMessage)
+    public function jobFailed(Throwable $e, bool $throwException, string $errorMessage): void
     {
         static::$latestResult = 'exception_thrown';
         static::$latestError = $errorMessage;
@@ -47,7 +47,7 @@ it('calls the jobFailed function when the job fails', function () {
     try {
         // When we dispatch the action whilst telling it to throw an exception.
         AsJobWithFailureTest::dispatch(true, 'something went wrong');
-    } catch (Throwable $e) {
+    } catch (Throwable) {
         // Then an exception was thrown and the jobFailed method was executed.
         expect(AsJobWithFailureTest::$latestResult)->toBe('exception_thrown');
         expect(AsJobWithFailureTest::$latestError)->toBe('something went wrong');

--- a/tests/AsJobWithJobDecoratorTest.php
+++ b/tests/AsJobWithJobDecoratorTest.php
@@ -12,12 +12,12 @@ class AsJobWithJobDecoratorTest
     public static ?int $latestResult;
     public static ?JobDecorator $latestJobDecorator;
 
-    public function handle(int $left, int $right)
+    public function handle(int $left, int $right): void
     {
         static::$latestResult = $left + $right;
     }
 
-    public function asJob(JobDecorator $job, int $left, int $right)
+    public function asJob(JobDecorator $job, int $left, int $right): void
     {
         static::$latestJobDecorator = $job;
         $this->handle($left, $right);

--- a/tests/AsJobWithMiddlewareTest.php
+++ b/tests/AsJobWithMiddlewareTest.php
@@ -27,7 +27,7 @@ class AsJobWithMiddlewareTest
         ];
     }
 
-    public function handle(string $operation, $left, $right)
+    public function handle(string $operation, $left, $right): void
     {
         static::$latestResult = $operation === 'addition'
             ? $left + $right

--- a/tests/AsJobWithUniqueHintedAsJobDecoratorTest.php
+++ b/tests/AsJobWithUniqueHintedAsJobDecoratorTest.php
@@ -14,12 +14,12 @@ class AsJobWithUniqueHintedAsJobDecoratorTest implements ShouldBeUnique
     public static ?int $latestResult;
     public static ?JobDecorator $latestJobDecorator;
 
-    public function handle(int $left, int $right)
+    public function handle(int $left, int $right): void
     {
         static::$latestResult = $left + $right;
     }
 
-    public function asJob(JobDecorator $job, int $left, int $right)
+    public function asJob(JobDecorator $job, int $left, int $right): void
     {
         static::$latestJobDecorator = $job;
         $this->handle($left, $right);

--- a/tests/AsJobWithUniqueJobDecoratorTest.php
+++ b/tests/AsJobWithUniqueJobDecoratorTest.php
@@ -14,12 +14,12 @@ class AsJobWithUniqueJobDecoratorTest implements ShouldBeUnique
     public static ?int $latestResult;
     public static ?JobDecorator $latestJobDecorator;
 
-    public function handle(int $left, int $right)
+    public function handle(int $left, int $right): void
     {
         static::$latestResult = $left + $right;
     }
 
-    public function asJob(UniqueJobDecorator $job, int $left, int $right)
+    public function asJob(UniqueJobDecorator $job, int $left, int $right): void
     {
         static::$latestJobDecorator = $job;
         $this->handle($left, $right);

--- a/tests/AsListenerAndObjectTest.php
+++ b/tests/AsListenerAndObjectTest.php
@@ -19,7 +19,7 @@ class AsListenerAndObjectTest
         return $addition ? $left + $right : $left - $right;
     }
 
-    public function asListener(OperationRequestedEvent $event)
+    public function asListener(OperationRequestedEvent $event): void
     {
         static::$latestResult = $this->handle(
             $event->left,

--- a/tests/AsUniqueJobTest.php
+++ b/tests/AsUniqueJobTest.php
@@ -18,24 +18,24 @@ class AsUniqueJobTest implements ShouldBeUnique
 
     public static ?Repository $cache;
 
-    public function handle(int $id = 1)
+    public function handle(int $id = 1): void
     {
         //
     }
 
-    public function getJobUniqueId(int $id = 1)
+    public function getJobUniqueId(int $id = 1): int
     {
         return $id;
     }
 
-    public function getJobUniqueVia()
+    public function getJobUniqueVia(): Repository
     {
         return static::$cache = Cache::driver('array');
     }
 
-    public function getJobUniqueFor()
+    public function getJobUniqueFor(): int
     {
-        return 60; // 60 seconds.
+        return 60; // seconds
     }
 }
 

--- a/tests/AsUniqueJobUsingPropertiesTest.php
+++ b/tests/AsUniqueJobUsingPropertiesTest.php
@@ -16,7 +16,7 @@ class AsUniqueJobUsingPropertiesTest implements ShouldBeUnique
     public string $jobUniqueId = 'my_job_id';
     public int $jobUniqueFor = 120; // 2 minutes.
 
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -58,7 +58,7 @@ function assertJobPushed(string $class, ?Closure $callback = null): void
 
 function assertJobPushedWith(string $class, array $parameters = []): void
 {
-    assertJobPushed($class, function (JobDecorator $job) use ($class, $parameters) {
+    assertJobPushed($class, function (JobDecorator $job) use ($parameters) {
         return $job->getParameters() === $parameters;
     });
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,14 +7,20 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
-    protected function getPackageProviders($app)
+    /**
+     * Get package providers.
+     */
+    protected function getPackageProviders($app): array
     {
         return [
             ActionServiceProvider::class,
         ];
     }
 
-    public function getEnvironmentSetUp($app)
+    /**
+     * Define environment setup.
+     */
+    public function getEnvironmentSetUp($app): void
     {
         $app['config']->set('database.default', 'sqlite');
     }


### PR DESCRIPTION
Hi there,

Don't be shocked by the amount of files changed, but I felt like doing the following:

* Remove obsolete docblocks, and corrected a few.
* Added type hints where possible.
* Replaced `switch` with `match` (just looks better / cleaner imho)
* Added the new `$jobDeleteWhenMissingModels` property / getter to `AsJob.php`

There were quite a few return types missing in the test files, that's why it looks so much.

Hope you like it, and feel free to contact me if you have any questions / remarks.
You are free to close this PR if you don't like it of course, but static analysis tools will be (more) happy eventually. 😉

👋 Edwin