### PR TITLE
Add assert with params convenience methods 

### DIFF
--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -169,4 +169,29 @@ trait AsJob
             return $callback ? $callback(...func_get_args()) : true;
         });
     }
+
+    public static function assertPushedWithParams(Closure|array $callback, ?string $queue = null): void
+    {
+        if (is_array($callback)) {
+            $callback = fn (...$params) => $params === $callback;
+        }
+
+        static::assertPushed(
+            fn ($action, $params, JobDecorator $job, $q) => $callback(...$params) && (is_null($queue) || $q === $queue)
+        );
+    }
+
+    public static function assertPushedWithParamsOn(string $queue, Closure|array $callback): void
+    {
+        static::assertPushedWithParams($callback, $queue);
+    }
+
+    public static function assertNotPushedWithParams(Closure|array $callback): void
+    {
+        if (is_array($callback)) {
+            $callback = fn (...$params) => $params === $callback;
+        }
+
+        static::assertNotPushed(fn ($action, $params, JobDecorator $job) => $callback(...$job->getParameters()));
+    }
 }

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -170,7 +170,7 @@ trait AsJob
         });
     }
 
-    public static function assertPushedWithParams(Closure|array $callback, ?string $queue = null): void
+    public static function assertPushedWith(Closure|array $callback, ?string $queue = null): void
     {
         if (is_array($callback)) {
             $callback = fn (...$params) => $params === $callback;
@@ -183,10 +183,10 @@ trait AsJob
 
     public static function assertPushedWithParamsOn(string $queue, Closure|array $callback): void
     {
-        static::assertPushedWithParams($callback, $queue);
+        static::assertPushedWith($callback, $queue);
     }
 
-    public static function assertNotPushedWithParams(Closure|array $callback): void
+    public static function assertNotPushedWith(Closure|array $callback): void
     {
         if (is_array($callback)) {
             $callback = fn (...$params) => $params === $callback;

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -181,11 +181,6 @@ trait AsJob
         );
     }
 
-    public static function assertPushedWithParamsOn(string $queue, Closure|array $callback): void
-    {
-        static::assertPushedWith($callback, $queue);
-    }
-
     public static function assertNotPushedWith(Closure|array $callback): void
     {
         if (is_array($callback)) {

--- a/tests/AsJobTest.php
+++ b/tests/AsJobTest.php
@@ -54,7 +54,7 @@ it('can be dispatched synchronously with parameters', function () {
     AsJobTest::dispatchNow(...$parameters);
 
     // Then it was pushed to the queue with these parameters.
-    assertJobPushedWith(AsJobTest::class, $parameters);
+    AsJobTest::assertPushedWithParams($parameters);
 });
 
 it('can be dispatched asynchronously', function () {
@@ -75,7 +75,7 @@ it('can be dispatched asynchronously with parameters', function () {
     AsJobTest::dispatch(...$parameters);
 
     // Then it was pushed to the queue with these parameters.
-    assertJobPushedWith(AsJobTest::class, $parameters);
+    AsJobTest::assertPushedWithParams($parameters);
 });
 
 it('can make a job statically', function (string $expectedJobClass) {

--- a/tests/AsJobTest.php
+++ b/tests/AsJobTest.php
@@ -54,7 +54,7 @@ it('can be dispatched synchronously with parameters', function () {
     AsJobTest::dispatchNow(...$parameters);
 
     // Then it was pushed to the queue with these parameters.
-    AsJobTest::assertPushedWithParams($parameters);
+    AsJobTest::assertPushedWith($parameters);
 });
 
 it('can be dispatched asynchronously', function () {
@@ -75,7 +75,7 @@ it('can be dispatched asynchronously with parameters', function () {
     AsJobTest::dispatch(...$parameters);
 
     // Then it was pushed to the queue with these parameters.
-    AsJobTest::assertPushedWithParams($parameters);
+    AsJobTest::assertPushedWith($parameters);
 });
 
 it('can make a job statically', function (string $expectedJobClass) {

--- a/tests/AsJobWithAssertionsTest.php
+++ b/tests/AsJobWithAssertionsTest.php
@@ -164,50 +164,6 @@ it('asserts an action has been pushed with params - failure (using array)', func
     AsJobWithAssertionsTest::assertPushedWith([$userB]);
 })->with('custom job decorators');
 
-it('asserts an action has been pushed with params on a given queue - success', function () {
-    loadMigrations();
-    $user = createUser();
-
-    // When we dispatch the action with some parameters on "some-queue".
-    AsJobWithAssertionsTest::setQueue('some-queue');
-    AsJobWithAssertionsTest::dispatch($user);
-
-    // Then we can assert it has been dispatched with these parameters on that queue.
-    AsJobWithAssertionsTest::assertPushedWithParamsOn('some-queue', $user->is(...));
-    AsJobWithAssertionsTest::assertPushedWithParamsOn('some-queue', [$user]);
-})->with('custom job decorators');
-
-it('asserts an action has been pushed with params on a given queue - failure (wrong params)', function () {
-    loadMigrations();
-    $userA = createUser();
-    $userB = createUser();
-
-    // When we dispatch the action with some parameters on "some-queue".
-    AsJobWithAssertionsTest::setQueue('some-queue');
-    AsJobWithAssertionsTest::dispatch($userA);
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('The expected ['.AsJobWithAssertionsTest::class.'] job was not pushed');
-
-    // Then we can expect a failure when asserting it has been dispatched with other parameters on that queue.
-    AsJobWithAssertionsTest::assertPushedWithParamsOn('some-queue', $userB->is(...));
-})->with('custom job decorators');
-
-it('asserts an action has been pushed with params on a given queue - failure (wrong queue)', function () {
-    loadMigrations();
-    $user = createUser();
-
-    // When we dispatch the action with some parameters on "some-queue".
-    AsJobWithAssertionsTest::setQueue('some-queue');
-    AsJobWithAssertionsTest::dispatch($user);
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('The expected ['.AsJobWithAssertionsTest::class.'] job was not pushed');
-
-    // Then we can expect a failure when asserting it has been dispatched with these parameters on some other queue.
-    AsJobWithAssertionsTest::assertPushedWithParamsOn('some-other-queue', $user->is(...));
-})->with('custom job decorators');
-
 it('asserts an action has not been pushed with params - success', function () {
     loadMigrations();
     $userA = createUser();

--- a/tests/AsJobWithAssertionsTest.php
+++ b/tests/AsJobWithAssertionsTest.php
@@ -134,7 +134,7 @@ it('asserts an action has been pushed with params - success', function () {
     AsJobWithAssertionsTest::assertPushedWithParams([$user]);
 })->with('custom job decorators');
 
-it('asserts an action has been pushed with params - failure', function () {
+it('asserts an action has been pushed with params - failure (using closure)', function () {
     loadMigrations();
     $userA = createUser();
     $userB = createUser();
@@ -147,6 +147,21 @@ it('asserts an action has been pushed with params - failure', function () {
 
     // Then we can expect a failure when asserting it has been dispatched with other parameters.
     AsJobWithAssertionsTest::assertPushedWithParams(fn (User $u) => $userB->is($u));
+})->with('custom job decorators');
+
+it('asserts an action has been pushed with params - failure (using array)', function () {
+    loadMigrations();
+    $userA = createUser();
+    $userB = createUser();
+
+    // When we dispatch the action with some parameters.
+    AsJobWithAssertionsTest::dispatch($userA);
+
+    $this->expectException(ExpectationFailedException::class);
+    $this->expectExceptionMessage('The expected ['.AsJobWithAssertionsTest::class.'] job was not pushed');
+
+    // Then we can expect a failure when asserting it has been dispatched with other parameters.
+    AsJobWithAssertionsTest::assertPushedWithParams([$userB]);
 })->with('custom job decorators');
 
 it('asserts an action has been pushed with params on a given queue - success', function () {

--- a/tests/AsJobWithAssertionsTest.php
+++ b/tests/AsJobWithAssertionsTest.php
@@ -130,8 +130,8 @@ it('asserts an action has been pushed with params - success', function () {
     AsJobWithAssertionsTest::dispatch($user);
 
     // Then we can assert it has been dispatched with these parameters.
-    AsJobWithAssertionsTest::assertPushedWithParams(fn (User $u) => $user->is($u));
-    AsJobWithAssertionsTest::assertPushedWithParams([$user]);
+    AsJobWithAssertionsTest::assertPushedWith(fn (User $u) => $user->is($u));
+    AsJobWithAssertionsTest::assertPushedWith([$user]);
 })->with('custom job decorators');
 
 it('asserts an action has been pushed with params - failure (using closure)', function () {
@@ -146,7 +146,7 @@ it('asserts an action has been pushed with params - failure (using closure)', fu
     $this->expectExceptionMessage('The expected ['.AsJobWithAssertionsTest::class.'] job was not pushed');
 
     // Then we can expect a failure when asserting it has been dispatched with other parameters.
-    AsJobWithAssertionsTest::assertPushedWithParams(fn (User $u) => $userB->is($u));
+    AsJobWithAssertionsTest::assertPushedWith(fn (User $u) => $userB->is($u));
 })->with('custom job decorators');
 
 it('asserts an action has been pushed with params - failure (using array)', function () {
@@ -161,7 +161,7 @@ it('asserts an action has been pushed with params - failure (using array)', func
     $this->expectExceptionMessage('The expected ['.AsJobWithAssertionsTest::class.'] job was not pushed');
 
     // Then we can expect a failure when asserting it has been dispatched with other parameters.
-    AsJobWithAssertionsTest::assertPushedWithParams([$userB]);
+    AsJobWithAssertionsTest::assertPushedWith([$userB]);
 })->with('custom job decorators');
 
 it('asserts an action has been pushed with params on a given queue - success', function () {
@@ -217,6 +217,6 @@ it('asserts an action has not been pushed with params - success', function () {
     AsJobWithAssertionsTest::dispatch($userA);
 
     // Then we can assert it has not been dispatched with these parameters.
-    AsJobWithAssertionsTest::assertNotPushedWithParams(fn (User $u) => $userB->is($u));
-    AsJobWithAssertionsTest::assertNotPushedWithParams([$userB]);
+    AsJobWithAssertionsTest::assertNotPushedWith(fn (User $u) => $userB->is($u));
+    AsJobWithAssertionsTest::assertNotPushedWith([$userB]);
 })->with('custom job decorators');

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -55,10 +55,3 @@ function assertJobPushed(string $class, ?Closure $callback = null): void
         return $callback ? $callback($job) : true;
     });
 }
-
-function assertJobPushedWith(string $class, array $parameters = []): void
-{
-    assertJobPushed($class, function (JobDecorator $job) use ($parameters) {
-        return $job->getParameters() === $parameters;
-    });
-}


### PR DESCRIPTION
### Problem

When I am testing that actions are pushed correctly, I almost always want to check the parameters that it is pushed with.

Currently it is a little cumbersome to check the params, as they are passed in as an array.

```php
SendPodcastPublishedEmail::dispatch($user, $podcast);

// currently...
SendPodcastPublishedEmail::assertPushed(fn ($a, $params) => $params[0]->is($user) && $params[1]->is($podcast));
```
Additionally, the thing I want to check is in the second argument so I have an unused variable.

### Solution
If we spread the params into the callback we can use type safety to check we have the correct type and shortcut the param check.

```php
SendPodcastPublishedEmail::dispatch($user, $podcast);

// assert by closure
SendPodcastPublishedEmail::assertPushedWithParams(fn (User $u, Podcast $p) => $user->is($u) && $podcast->is($p));
```

Or we can assert by an array
```php
// assert by array
SendPodcastPublishedEmail::assertPushedWithParams([$user, $podcast]);
```

Or my favourite way if the action only has a single param.
```php
SendWelcomeEmail::dispatch($user);

// assert by first class callable
SendWelcomeEmail::assertPushedWithParams($user->is(...));
```

This PR also adds the ability to assert the queue using `assertPushedWithParamsOn()`, and assert that an action wasn't pushed with params using `assertNotPushedWithParams()`

I later found a test helper `assertJobPushedWith()` that could be replaced.

Note: Naming the methods `assertPushedWith()`, `assertNotPushedWith()` also works well, but sounds a little strange when checking the queue as well `assertPushedWithOn()` I'm easy either way.