### PR TITLE
Ability to define resourceful Action routes

### DIFF
--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -3,11 +3,13 @@
 namespace Lorisleiva\Actions;
 
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Lorisleiva\Actions\Console\MakeActionCommand;
 use Lorisleiva\Actions\DesignPatterns\CommandDesignPattern;
 use Lorisleiva\Actions\DesignPatterns\ControllerDesignPattern;
 use Lorisleiva\Actions\DesignPatterns\ListenerDesignPattern;
+use Lorisleiva\Actions\Macros\ActionRouteMacros;
 
 class ActionServiceProvider extends ServiceProvider
 {
@@ -43,6 +45,8 @@ class ActionServiceProvider extends ServiceProvider
                 MakeActionCommand::class,
             ]);
         }
+
+        Route::mixin(new ActionRouteMacros);
     }
 
     protected function extendActions(): void

--- a/src/Macros/ActionRouteMacros.php
+++ b/src/Macros/ActionRouteMacros.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lorisleiva\Actions\Macros;
+
+use Illuminate\Routing\PendingResourceRegistration;
+use Illuminate\Routing\Router;
+use Lorisleiva\Actions\Routing\ActionResourceRegistrar;
+
+class ActionRouteMacros
+{
+    public function actions(): callable
+    {
+        return function (string $name, string $namespace, array $options = []): PendingResourceRegistration {
+            /** @var Router $router */
+            $router = $this;
+            $registrar = new ActionResourceRegistrar($router);
+
+            return new PendingResourceRegistration(
+                $registrar, $name, $namespace, $options
+            );
+        };
+    }
+}

--- a/src/Macros/ActionRouteMacros.php
+++ b/src/Macros/ActionRouteMacros.php
@@ -10,7 +10,7 @@ class ActionRouteMacros
 {
     public function actions(): callable
     {
-        return function (string $name, string $namespace, array $options = []): PendingResourceRegistration {
+        return function (string $name, string $namespace = 'App\Actions', array $options = []): PendingResourceRegistration {
             /** @var Router $router */
             $router = $this;
             $registrar = new ActionResourceRegistrar($router);

--- a/src/Routing/ActionResourceRegistrar.php
+++ b/src/Routing/ActionResourceRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lorisleiva\Actions\Routing;
+
+use Illuminate\Routing\ResourceRegistrar;
+use Illuminate\Support\Str;
+
+class ActionResourceRegistrar extends ResourceRegistrar
+{
+    protected function getResourceAction($resource, $controller, $method, $options): array
+    {
+        $action = parent::getResourceAction($resource, $controller, $method, $options);
+
+        $resource = Str::camel($resource);
+        $actionName = Str::singular($resource);
+
+        $actionClass = match ($method) {
+            'index' => 'Get'.ucfirst($resource),
+            'create' => 'Create'.ucfirst($actionName),
+            'show' => 'Show'.ucfirst($actionName),
+            'edit' => 'Edit'.ucfirst($actionName),
+            'store' => 'Store'.ucfirst($actionName),
+            'update' => 'Update'.ucfirst($actionName),
+            'destroy' => 'Destroy'.ucfirst($actionName),
+        };
+
+        // Replaces the Controller@action string with the ActionClass string
+        $action['uses'] = str_replace('\\\\', '\\', "{$controller}\\{$actionClass}");
+
+        return $action;
+    }
+}

--- a/src/Routing/ActionResourceRegistrar.php
+++ b/src/Routing/ActionResourceRegistrar.php
@@ -16,10 +16,10 @@ class ActionResourceRegistrar extends ResourceRegistrar
 
         $actionClass = match ($method) {
             'index' => 'Get'.ucfirst($resource),
-            'create' => 'Create'.ucfirst($actionName),
+            'create' => 'ShowCreate'.ucfirst($actionName),
             'show' => 'Show'.ucfirst($actionName),
-            'edit' => 'Edit'.ucfirst($actionName),
-            'store' => 'Store'.ucfirst($actionName),
+            'edit' => 'ShowEdit'.ucfirst($actionName),
+            'store' => 'Create'.ucfirst($actionName),
             'update' => 'Update'.ucfirst($actionName),
             'destroy' => 'Destroy'.ucfirst($actionName),
         };

--- a/src/Routing/ActionResourceRegistrar.php
+++ b/src/Routing/ActionResourceRegistrar.php
@@ -21,7 +21,7 @@ class ActionResourceRegistrar extends ResourceRegistrar
             'edit' => 'ShowEdit'.ucfirst($actionName),
             'store' => 'Create'.ucfirst($actionName),
             'update' => 'Update'.ucfirst($actionName),
-            'destroy' => 'Destroy'.ucfirst($actionName),
+            'destroy' => 'Delete'.ucfirst($actionName),
         };
 
         // Replaces the Controller@action string with the ActionClass string


### PR DESCRIPTION
I absolutely love this package, but the only thing I don't like is having to declare all of my Action routes individually, and losing the ability to define resorceful routes.

This PR attempts to achieve this, by leveraging the `Route::resource()` function and swaping out the `Controller@action` for the action class.

Example usage:

```php
// By default, it will look for all actions in the App\Actions namespace
Route::actions('addresses');

// If we only want to to generate index/show routes
Route::actions('addresses')->only('index', 'show');

// If our action is not in the default namespace, we can specify the namespace
Route::actions('addresses', 'App\Actions\Addresses');

// Because we are leveraging the Route::resource() method, all other helpers are readily available for us to chain on to
Route::actions('addresses')->only('index')->middleware('signed');
```

The benefit of this is that it will force developers to have consistent routing AND consistent Action naming. Now the names of these are up for grabs, but I've gone for:

- `GetAddresses` - this replaces `Controller@index`
- `ShowCreateAddress` - this replaces `Controller@create`
- `ShowAddress` - this replaces `Controller@show`
- `ShowEditAddress` - this replaces `Controller@edit`
- `CreateAddress` - this replaces `Controller@store`
- `UpdateAddress` - this replaces `Controller@update`
- `DeleteAddress` - this replaces `Controller@destroy`

Example - the following two resourceful action declarations:

```php
Route::actions('addresses');
Route::actions('order-items');
```

produces the following routes:

![image](https://github.com/user-attachments/assets/d7ac0e85-a35b-4269-a189-31448f50fce9)
