### PR TITLE
Fixed implicitly nullable parameter

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -131,7 +131,7 @@ class ActionManager
         return $designPattern->decorate($instance, $frame);
     }
 
-    public function identifyFromBacktrace($usedTraits, BacktraceFrame &$frame = null): ?DesignPattern
+    public function identifyFromBacktrace($usedTraits, ?BacktraceFrame &$frame = null): ?DesignPattern
     {
         $designPatterns = $this->getDesignPatternsMatching($usedTraits);
         $backtraceOptions = DEBUG_BACKTRACE_PROVIDE_OBJECT


### PR DESCRIPTION
Fixes deprecation error in PHP 8.4