### PR TITLE
Add shouldExpect() mocking method

### DIFF
--- a/src/Concerns/AsFake.php
+++ b/src/Concerns/AsFake.php
@@ -41,6 +41,11 @@ trait AsFake
         return static::mock()->shouldReceive('handle');
     }
 
+    public static function shouldExpect(): Expectation|ExpectationInterface|HigherOrderMessage
+    {
+        return static::mock()->expects('handle');
+    }
+
     public static function shouldNotRun(): Expectation|ExpectationInterface|HigherOrderMessage
     {
         return static::mock()->shouldNotReceive('handle');

--- a/tests/AsFakeTest.php
+++ b/tests/AsFakeTest.php
@@ -74,6 +74,19 @@ it('can mock an action expecting for it to run', function () {
     expect($result)->toBe(3);
 });
 
+it('can mock an action expecting for it to run only once', function () {
+    // Given we mock the action with the
+    // expection it should run only once.
+    AsFakeTest::shouldExpect();
+
+    // When we run the action more than once.
+    AsFakeTest::run('addition', 1, 2);
+    AsFakeTest::run('addition', 1, 2);
+
+    // Then we expect a mocking exception.
+    Mockery::close();
+})->throws(InvalidCountException::class);
+
 it('can mock an action expecting for it not to run', function () {
     // Given we mock the action with the
     // expectation that it should not run.


### PR DESCRIPTION
This PR adds the static `shouldExpect` method to the `AsFake` trait.

This exposes the behavior of Mockery's [`->expects()`](https://docs.mockery.io/en/latest/reference/alternative_should_receive_syntax.html?highlight=expects#expects). Users will now be able to use `::shouldExpect()` to declare that a mocked action should run once and only once.

Fixes #278