### PR TITLE
Fix php8.4 deprecated notices

### DIFF
--- a/src/Exceptions/MissingCommandSignatureException.php
+++ b/src/Exceptions/MissingCommandSignatureException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class MissingCommandSignatureException extends Exception
 {
-    public function __construct($action, $code = 0, Throwable $previous = null)
+    public function __construct($action, $code = 0, ?Throwable $previous = null)
     {
         $message = sprintf(
             'The command signature is missing from your [%s] action. Use `public string $commandSignature` to set it up.',


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Lorisleiva\Actions\Exceptions\MissingCommandSignatureException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in ./src/Exceptions/MissingCommandSignatureException.php on line 10
```