### PR TITLE
Enable Precogitition support for ActionRequests

### DIFF
--- a/src/ActionRequest.php
+++ b/src/ActionRequest.php
@@ -11,7 +11,10 @@ class ActionRequest extends FormRequest
 
     public function validateResolved(): void
     {
-        // Cancel the auto-resolution trait.
+        // Only run auto-resolution trait for precognitive requests.
+        if (request()->isPrecognitive()) {
+            parent::validateResolved();
+        }
     }
 
     public function getDefaultValidationData(): array

--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Concerns\CanBePrecognitive;
 use Illuminate\Routing\Redirector;
 use Illuminate\Validation\ValidationException;
 
@@ -67,9 +68,13 @@ trait ValidateActions
 
     protected function createDefaultValidator(ValidationFactory $factory): Validator
     {
-        return $factory->make(
+        $rules = $this->rules();
+        if (in_array(CanBePrecognitive::class, class_uses_recursive($this)) && $this->isPrecognitive())
+            $rules = $this->filterPrecognitiveRules($rules);
+
+        return  $factory->make(
             $this->validationData(),
-            $this->rules(),
+            $rules,
             $this->messages(),
             $this->attributes()
         );

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -33,6 +33,7 @@ class ControllerDecorator
         if ($this->hasMethod('getControllerMiddleware')) {
             $this->middleware = $this->resolveAndCallMethod('getControllerMiddleware');
         }
+        app()->extend(ActionRequest::class, fn(ActionRequest $request) => $request->setAction($action));
     }
 
     public function getRoute(): Route

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -59,7 +59,7 @@ class ControllerDecorator
     public function __invoke(string $method)
     {
         $this->refreshAction();
-        $request = $this->refreshRequest();
+        $request = app(ActionRequest::class);
 
         if ($this->shouldValidateRequest($method)) {
             $request->validate();
@@ -83,18 +83,6 @@ class ControllerDecorator
         }
 
         $this->executedAtLeastOne = true;
-    }
-
-    protected function refreshRequest(): ActionRequest
-    {
-        app()->forgetInstance(ActionRequest::class);
-
-        /** @var ActionRequest $request */
-        $request = app(ActionRequest::class);
-        $request->setAction($this->action);
-        app()->instance(ActionRequest::class, $request);
-
-        return $request;
     }
 
     protected function replaceRouteMethod(): void

--- a/src/Decorators/ControllerDecorator.php
+++ b/src/Decorators/ControllerDecorator.php
@@ -3,12 +3,14 @@
 namespace Lorisleiva\Actions\Decorators;
 
 use Illuminate\Container\Container;
+use Illuminate\Foundation\Routing\PrecognitionControllerDispatcher;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteDependencyResolverTrait;
 use Illuminate\Support\Str;
 use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\DecorateActions;
 use Lorisleiva\Actions\Concerns\WithAttributes;
+use Lorisleiva\Actions\Routing\PrecognitionActionControllerDispatcher;
 
 class ControllerDecorator
 {
@@ -33,6 +35,7 @@ class ControllerDecorator
         if ($this->hasMethod('getControllerMiddleware')) {
             $this->middleware = $this->resolveAndCallMethod('getControllerMiddleware');
         }
+        app()->bind(PrecognitionControllerDispatcher::class, PrecognitionActionControllerDispatcher::class);
         app()->extend(ActionRequest::class, fn(ActionRequest $request) => $request->setAction($action));
     }
 

--- a/src/Routing/Middleware/HandlePrecognitiveActionRequests.php
+++ b/src/Routing/Middleware/HandlePrecognitiveActionRequests.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lorisleiva\Actions\Routing\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Routing\Contracts\ControllerDispatcher;
+use Lorisleiva\Actions\Routing\PrecognitionActionControllerDispatcher;
+
+class HandlePrecognitiveActionRequests extends HandlePrecognitiveRequests
+{
+
+    /**
+     * Prepare to handle a precognitive request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function prepareForPrecognition($request)
+    {
+        parent::prepareForPrecognition($request);
+
+        $this->container->bind(ControllerDispatcher::class, PrecognitionActionControllerDispatcher::class);
+    }
+}

--- a/src/Routing/PrecognitionActionControllerDispatcher.php
+++ b/src/Routing/PrecognitionActionControllerDispatcher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lorisleiva\Actions\Routing;
+
+use Illuminate\Foundation\Routing\PrecognitionControllerDispatcher;
+use Illuminate\Routing\Route;
+use Lorisleiva\Actions\Decorators\ControllerDecorator;
+
+class PrecognitionActionControllerDispatcher extends PrecognitionControllerDispatcher
+{
+    /**
+     * Dispatch a request to a given controller and method.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  mixed  $controller
+     * @param  string  $method
+     * @return void
+     */
+    public function dispatch(Route $route, $controller, $method)
+    {
+        // In order to work with Laravel Actions
+        // we need the controller class from the route action
+        if ($controller instanceof ControllerDecorator) {
+            $controller = $route->action["controller"];
+        }
+        parent::dispatch($route, $controller, $method);
+    }
+}

--- a/tests/AsControllerWithPrecognitionTest.php
+++ b/tests/AsControllerWithPrecognitionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Lorisleiva\Actions\ActionRequest;
+use Lorisleiva\Actions\Concerns\AsController;
+use Lorisleiva\Actions\Concerns\AsFake;
+use Lorisleiva\Actions\Routing\Middleware\HandlePrecognitiveActionRequests;
+
+class AsControllerWithPrecognitionTest
+{
+    use AsController, AsFake;
+
+    public function authorize(ActionRequest $request): bool
+    {
+        return $request->header('auth') !== 'unauthorized';
+    }
+
+    public function rules(): array
+    {
+        return [
+            'requiredString' => ['required', 'string'],
+            'optionalNumber' => ['numeric'],
+        ];
+    }
+
+    public function handle(ActionRequest $request)
+    {
+        return $request->get('requiredString');
+    }
+}
+
+beforeEach(function () {
+    Route::post('/normal', AsControllerWithPrecognitionTest::class);
+    Route::middleware(HandlePrecognitiveActionRequests::class)->post(
+        '/precognition',
+        AsControllerWithPrecognitionTest::class,
+    );
+});
+
+it('correctly handles successful precognitive requests', function () {
+    AsControllerWithPrecognitionTest::partialMock()->shouldNotReceive('handle');
+    $request = $this->withHeader('Precognition', 'true')
+        ->postJson('/precognition', ['requiredString' => 'test'])
+        ->assertNoContent()
+        ->assertHeader('Precognition', true);
+    // only present on Laravel 10.11.0+ (#47081)
+    if (version_compare(app()->version(), '10.11.0', '>='))
+        $request->assertHeader('Precognition-Success', true);
+});
+
+it('correctly handles successful precognitive validate only requests', function () {
+    AsControllerWithPrecognitionTest::partialMock()->shouldNotReceive('handle');
+    $request = $this->withHeader('Precognition', 'true')
+        ->withHeader('Precognition-Validate-Only', 'optionalNumber')
+        ->postJson('/precognition', ['optionalNumber' => '5'])
+        ->assertNoContent()
+        ->assertHeader('Precognition', true);
+    // only present on Laravel 10.11.0+ (#47081)
+    if (version_compare(app()->version(), '10.11.0', '>='))
+        $request->assertHeader('Precognition-Success', true);
+});
+
+it('correctly handles unsuccessful precognitive requests', function () {
+    AsControllerWithPrecognitionTest::partialMock()->shouldNotReceive('handle');
+    $this->withHeader('Precognition', 'true')
+        ->postJson('/precognition', ['optionalNumber' => 'NaN'])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrorFor('requiredString')
+        ->assertJsonValidationErrorFor('optionalNumber')
+        ->assertHeader('Precognition', true)
+        ->assertHeaderMissing('Precognition-Success');
+});
+
+it('correctly handles unsuccessful precognitive validate only requests', function () {
+    AsControllerWithPrecognitionTest::partialMock()->shouldNotReceive('handle');
+    $this->withHeader('Precognition', 'true')
+        ->withHeader('Precognition-Validate-Only', 'optionalNumber')
+        ->postJson('/precognition', ['optionalNumber' => 'NaN'])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrorFor('optionalNumber')
+        ->assertJsonMissingValidationErrors('requiredString')
+        ->assertHeader('Precognition', true)
+        ->assertHeaderMissing('Precognition-Success');
+});
+
+it('does not mistakenly make non-precognition actions precognitive', function () {
+    $string = fake()->text();
+    $this->withHeader('Precognition', 'true')
+        ->postJson('/normal', ['requiredString' => $string, 'optionalNumber' => '5'])
+        ->assertContent($string)
+        ->assertOk()
+        ->assertHeaderMissing('Precognition')
+        ->assertHeaderMissing('Precognition-Success');
+});
+
+it('does not mistakenly make non-precognition actions precognitive with validate only', function () {
+    $this->withHeader('Precognition', 'true')
+        ->withHeader('Precognition-Validate-Only', 'optionalNumber')
+        ->postJson('/normal', ['optionalNumber' => 'NaN'])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrorFor('optionalNumber')
+        ->assertJsonValidationErrorFor('requiredString')
+        ->assertHeaderMissing('Precognition')
+        ->assertHeaderMissing('Precognition-Success');
+});


### PR DESCRIPTION
Hey, I've spent the last week poking and prodding at supporting Precognition in Laravel-Actions in a clean enough way. I believe I've done that as I've not found a cleaner way. I've written as many tests to double check my work and validate I've not broken anything else in my wake. I did not add support to `WithAttributes` as I have no intentions of using it and it's path for supporting Precognition differs since it does not use `FormRequest`s.

I have a PR open in laravel/framework (laravel/framework#54514) for 4c4720ac2123466f7dc444733e71ea22c9f889bb to make it automagical using the normal middleware, but I have added a [middleware](https://github.com/Spice-King/laravel-actions/blob/4c4720ac2123466f7dc444733e71ea22c9f889bb/src/Routing/Middleware/HandlePrecognitiveActionRequests.php) that makes the needed tweaks for Actions in Precognition for both backwards compatibility in older versions of Laravel and in the event they opt to deny/close the PR.