### PR TITLE
Injects route parameters into action authorize

### DIFF
--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -133,8 +133,12 @@ trait ValidateActions
     protected function inspectAuthorization(): Response
     {
         try {
+            $routeParameters = method_exists($this, 'route') ? $this->route()->parameters() : null;
+
             $response = $this->hasMethod('authorize')
-                ? $this->resolveAndCallMethod('authorize')
+                ? ($routeParameters
+                    ? $this->resolveAndCallMethod('authorize', $routeParameters)
+                    : $this->resolveAndCallMethod('authorize'))
                 : true;
         } catch (AuthorizationException $e) {
             return $e->toResponse();

--- a/tests/AsControllerWithAuthorizeAndRulesTest.php
+++ b/tests/AsControllerWithAuthorizeAndRulesTest.php
@@ -32,9 +32,25 @@ class AsControllerWithAuthorizeAndRulesTest
     }
 }
 
+class AsControllerWithAuthorizeBindingsTest
+{
+    use AsController;
+
+    public function authorize(string $someRouteParameter): bool
+    {
+        return $someRouteParameter !== 'unauthorized';
+    }
+
+    public function handle(ActionRequest $request, string $someRouteParameter)
+    {
+        return [$someRouteParameter];
+    }
+}
+
 beforeEach(function () {
     // Given the action is registered as a controller.
     Route::post('/calculator', AsControllerWithAuthorizeAndRulesTest::class);
+    Route::get('/authorize-bindings/{someRouteParameter}', AsControllerWithAuthorizeBindingsTest::class);
 });
 
 it('passes authorization and validation', function () {
@@ -85,4 +101,9 @@ it('uses a new validator at every request', function () {
 
     $this->post('/calculator', ['operation' => 'invalid'])
         ->assertSessionHasErrors(['operation', 'right', 'left']);
+});
+
+it('resolves route parameters as authorization arguments', function () {
+    $this->get('/authorize-bindings/authorized')->assertOk()->assertExactJson(['authorized']);
+    $this->get('/authorize-bindings/unauthorized')->assertForbidden();
 });


### PR DESCRIPTION
## 💪 Motivation
<!-- What influenced this change/feature? -->

Currently, when running the authorize method on an Action, the only variable you can access is the ActionRequest by resolving it from the container via dependency injection. This can sometimes lead to the authorize method becoming messy if we need to access a route-model bound model, as an example, and authorize that a certain action can run based on the state of the particular model.

This example might explain it a bit better:

```php
// Current implementation
class ShowOrder
{
    use AsController;

    public function authorize(ActionRequest $request): bool
    {
        /** @var Order $order */
        $order = $request->order;

        return $order->status->is(OrderStatus::COMPLETE);
    }

    public function handle(Order $order): Response
    {
        // ...
    }
}

// New implementation
class ShowOrder
{
    use AsController;

    public function authorize(Order $order): bool
    {
        return $order->status->is(OrderStatus::COMPLETE);
    }

    public function handle(Order $order): Response
    {
        // ...
    }
}
```

The ActionRequest can still be resolved via dependency injection, so this isn't a breaking change.

## 🛠 Changes
<!-- What code changes were made? Anything significant? New paradigms or concepts? -->

- Pass route parameters into the `authorize` method, when authorizing the incoming request
- This allows us to tidy our authorize method, avoiding the need to pluck parameters from the request

## 🧪 Testing
<!-- What steps are needed in order to demonstrate this feature works as intended? -->

- A test has been added to `tests/AsControllerWithAuthorizeAndRulesTest.php`

## 🧙 Reminders (Author)
<!-- This list will become interactive after submission. -->
<!-- Place a ~ inside the checkbox if this task is not required for this MR. This serves to highlight to others that the task isn't outstanding, and hasn't been 'forgotten'. -->

- [x] Have you read through your own diff? 👀
- [x] Are all tests passing? 🧪
