### PR TITLE
Initialize $action property and guard hasMethod()

### DIFF
--- a/src/Concerns/DecorateActions.php
+++ b/src/Concerns/DecorateActions.php
@@ -4,7 +4,7 @@ namespace Lorisleiva\Actions\Concerns;
 
 trait DecorateActions
 {
-    protected mixed $action;
+    protected mixed $action = null;
 
     public function setAction($action): self
     {
@@ -30,7 +30,7 @@ trait DecorateActions
 
     protected function hasMethod(string $method): bool
     {
-        return method_exists($this->action, $method);
+        return isset($this->action) && method_exists($this->action, $method);
     }
 
     protected function callMethod(string $method, array $parameters = [])

--- a/tests/DecorateActionsTest.php
+++ b/tests/DecorateActionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Lorisleiva\Actions\ActionRequest;
+
+beforeEach(function () {
+    $this->request = new class extends ActionRequest {
+        public function authorize(): bool { return true; }
+        public function rules(): array   { return []; }
+        public function handle()          { /* no-op */ }
+    };
+
+    $method            = new \ReflectionMethod($this->request, 'hasMethod');
+    $method->setAccessible(true);
+    $this->hasMethod = $method;
+});
+
+it('returns false and does not throw when action is uninitialized', function () {
+    expect($this->hasMethod->invoke($this->request, 'anything'))
+        ->toBeFalse();
+});
+
+it('returns true for an existing method after setAction()', function () {
+    // A dummy action object declaring customFoo()
+    $dummyAction = new class {
+        public function customFoo(): string
+        {
+            return 'bar';
+        }
+    };
+
+    // Initialize the request’s $action
+    $this->request->setAction($dummyAction);
+
+    expect($this->hasMethod->invoke($this->request, 'customFoo'))
+        ->toBeTrue();
+});


### PR DESCRIPTION
When using ActionRequest under PHP 7.4+, calling method_exists($this->action, …) before $action has been initialized causes a fatal error:

    Typed property Lorisleiva\Actions\ActionRequest::$action must not be accessed before initialization
    
[Issue #313 ](https://github.com/lorisleiva/laravel-actions/issues/313)

This happens because typed properties in PHP 7.4+ are in an uninitialized state unless given a default value
[php.net](https://www.php.net/manual/en/language.oop5.properties.php)

Solution

    Initialize the $action property to null
    Ensures the property is always in a defined state.

    Guard the hasMethod() check with isset($this->action)
    Prevents calling method_exists() on an uninitialized property.


Testing

    ./vendor/bin/pest --filter=DecorateActionsTest
