### PR TITLE
Add PHPStan extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.0|^4.0",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5|^12.0"
     },
     "autoload": {
@@ -39,7 +40,10 @@
     "autoload-dev": {
         "psr-4": {
             "Lorisleiva\\Actions\\Tests\\": "tests"
-        }
+        },
+        "classmap": [
+            "tests/PHPStan/Fixtures"
+        ]
     },
     "scripts": {
         "test": "vendor/bin/pest --colors=always",
@@ -59,6 +63,11 @@
             "aliases": {
                 "Action": "Lorisleiva\\Actions\\Facades\\Actions"
             }
+        },
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
         }
     },
     "minimum-stability": "dev",

--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,8 @@ services:
 
     -
         class: Lorisleiva\Actions\PHPStan\RunThrowTypeExtension
+        arguments:
+            implicitThrows: %exceptions.implicitThrows%
         tags:
             - phpstan.dynamicStaticMethodThrowTypeExtension
 

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,18 @@
+services:
+    -
+        class: Lorisleiva\Actions\PHPStan\ActionHelper
+
+    -
+        class: Lorisleiva\Actions\PHPStan\RunReturnTypeExtension
+        tags:
+            - phpstan.broker.expressionTypeResolverExtension
+
+    -
+        class: Lorisleiva\Actions\PHPStan\RunThrowTypeExtension
+        tags:
+            - phpstan.dynamicStaticMethodThrowTypeExtension
+
+    -
+        class: Lorisleiva\Actions\PHPStan\RunParameterValidationRule
+        tags:
+            - phpstan.rules.rule

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -30,7 +30,7 @@ final class ActionHelper
         if ($call->class instanceof Name) {
             $callerType = $scope->resolveTypeByName($call->class);
         } else {
-            $callerType = $scope->getType($call->class);
+            $callerType = $scope->getType($call->class)->getObjectTypeOrClassStringObjectType();
         }
 
         $classReflections = $callerType->getObjectClassReflections();

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -59,7 +59,7 @@ final class ActionHelper
     }
 
     /**
-     * Removes the leading $boolean condition argument from a runIf()/runUnless() call,
+     * Removes the $boolean condition argument from a runIf()/runUnless() call,
      * so the remaining args line up with handle()'s parameters.
      *
      * @param array<Arg> $args
@@ -67,26 +67,50 @@ final class ActionHelper
      */
     public function stripConditionArg(array $args, string $methodName): array
     {
-        if (! ($methodName === 'runIf' || $methodName === 'runUnless')) {
+        $index = $this->findConditionArgIndex($args, $methodName);
+
+        if ($index === null) {
             return $args;
+        }
+
+        unset($args[$index]);
+
+        return array_values($args);
+    }
+
+    /**
+     * Finds the $boolean condition argument of a runIf()/runUnless() call.
+     *
+     * @param array<Arg> $args
+     */
+    public function getConditionArg(array $args, string $methodName): ?Arg
+    {
+        $index = $this->findConditionArgIndex($args, $methodName);
+
+        return $index === null ? null : $args[$index];
+    }
+
+    /** @param array<Arg> $args */
+    private function findConditionArgIndex(array $args, string $methodName): ?int
+    {
+        if (! ($methodName === 'runIf' || $methodName === 'runUnless')) {
+            return null;
         }
 
         if (count($args) === 0) {
-            return $args;
+            return null;
         }
 
         if ($args[0]->name === null) {
-            return array_slice($args, 1);
+            return 0;
         }
 
         foreach ($args as $i => $arg) {
             if ($arg->name !== null && $arg->name->toString() === 'boolean') {
-                unset($args[$i]);
-
-                return array_values($args);
+                return $i;
             }
         }
 
-        return $args;
+        return null;
     }
 }

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\PHPStan;
+
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+
+final class ActionHelper
+{
+    private const AS_OBJECT_TRAIT = 'Lorisleiva\Actions\Concerns\AsObject';
+
+    private const PROXY_METHODS = ['run', 'runIf', 'runUnless'];
+
+    public function resolveActionClass(StaticCall $call, Scope $scope): ?ClassReflection
+    {
+        if (! $call->name instanceof Identifier) {
+            return null;
+        }
+
+        if (! in_array($call->name->toString(), self::PROXY_METHODS, true)) {
+            return null;
+        }
+
+        if ($call->class instanceof Name) {
+            $callerType = $scope->resolveTypeByName($call->class);
+        } else {
+            $callerType = $scope->getType($call->class);
+        }
+
+        $classReflections = $callerType->getObjectClassReflections();
+
+        if (count($classReflections) !== 1) {
+            return null;
+        }
+
+        $classReflection = $classReflections[0];
+
+        if (! $classReflection->hasTraitUse(self::AS_OBJECT_TRAIT)) {
+            return null;
+        }
+
+        return $classReflection;
+    }
+
+    public function getHandleMethod(ClassReflection $classReflection): ?ExtendedMethodReflection
+    {
+        if (! $classReflection->hasMethod('handle')) {
+            return null;
+        }
+
+        return $classReflection->getNativeMethod('handle');
+    }
+}

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -65,6 +65,15 @@ final class ActionHelper
         return $classReflection->getNativeMethod('handle');
     }
 
+    /**
+     * static:: resolves to the declaring class, losing the subclass that will
+     * actually receive the call.
+     */
+    public function isLateStaticBinding(StaticCall $call): bool
+    {
+        return $call->class instanceof Name && $call->class->toLowerString() === 'static';
+    }
+
     /** @param array<Arg> $args */
     public function hasUnpackedArg(array $args): bool
     {

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -65,6 +65,18 @@ final class ActionHelper
         return $classReflection->getNativeMethod('handle');
     }
 
+    /** @param array<Arg> $args */
+    public function hasUnpackedArg(array $args): bool
+    {
+        foreach ($args as $arg) {
+            if ($arg->unpack) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Removes the $boolean condition argument from a runIf()/runUnless() call,
      * so the remaining args line up with handle()'s parameters.
@@ -105,6 +117,12 @@ final class ActionHelper
         }
 
         if (count($args) === 0) {
+            return null;
+        }
+
+        // An unpacked first argument may supply the condition and any number of
+        // handle() arguments, so none of them can be told apart.
+        if ($args[0]->unpack) {
             return null;
         }
 

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\MethodReflection;
 
 final class ActionHelper
 {
@@ -63,6 +64,12 @@ final class ActionHelper
         }
 
         return $classReflection->getNativeMethod('handle');
+    }
+
+    public function isActionProxyMethod(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), self::PROXY_METHODS, true)
+            && $methodReflection->getDeclaringClass()->hasTraitUse(self::AS_OBJECT_TRAIT);
     }
 
     /**

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -66,6 +66,11 @@ final class ActionHelper
         return $classReflection->getNativeMethod('handle');
     }
 
+    public function resolveProxyMethodName(StaticCall $call): ?string
+    {
+        return $call->name instanceof Identifier ? $call->name->toString() : null;
+    }
+
     public function isActionProxyMethod(MethodReflection $methodReflection): bool
     {
         return in_array($methodReflection->getName(), self::PROXY_METHODS, true)

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lorisleiva\Actions\PHPStan;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -55,5 +56,37 @@ final class ActionHelper
         }
 
         return $classReflection->getNativeMethod('handle');
+    }
+
+    /**
+     * Removes the leading $boolean condition argument from a runIf()/runUnless() call,
+     * so the remaining args line up with handle()'s parameters.
+     *
+     * @param array<Arg> $args
+     * @return array<Arg>
+     */
+    public function stripConditionArg(array $args, string $methodName): array
+    {
+        if (! ($methodName === 'runIf' || $methodName === 'runUnless')) {
+            return $args;
+        }
+
+        if (count($args) === 0) {
+            return $args;
+        }
+
+        if ($args[0]->name === null) {
+            return array_slice($args, 1);
+        }
+
+        foreach ($args as $i => $arg) {
+            if ($arg->name !== null && $arg->name->toString() === 'boolean') {
+                unset($args[$i]);
+
+                return array_values($args);
+            }
+        }
+
+        return $args;
     }
 }

--- a/src/PHPStan/ActionHelper.php
+++ b/src/PHPStan/ActionHelper.php
@@ -28,6 +28,11 @@ final class ActionHelper
             return null;
         }
 
+        // StaticCall::getArgs() asserts against being called on a first-class callable.
+        if ($call->isFirstClassCallable()) {
+            return null;
+        }
+
         if ($call->class instanceof Name) {
             $callerType = $scope->resolveTypeByName($call->class);
         } else {
@@ -51,7 +56,9 @@ final class ActionHelper
 
     public function getHandleMethod(ClassReflection $classReflection): ?ExtendedMethodReflection
     {
-        if (! $classReflection->hasMethod('handle')) {
+        // hasMethod() also reports @method, __call and @mixin methods, which
+        // getNativeMethod() then throws on.
+        if (! $classReflection->hasNativeMethod('handle')) {
             return null;
         }
 

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -153,6 +153,18 @@ final class RunParameterValidationRule implements Rule
             }
 
             if ($param === null) {
+                // A variadic handle() collects unmatched named arguments by key.
+                if ($arg->name !== null && ! $isVariadic) {
+                    $errors[] = RuleErrorBuilder::message(sprintf(
+                        'Unknown parameter $%s in call to %s::%s().',
+                        $arg->name->toString(),
+                        $classReflection->getDisplayName(),
+                        $methodName,
+                    ))
+                        ->identifier('laravelActions.unknownNamedArgument')
+                        ->build();
+                }
+
                 continue;
             }
 

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -61,6 +61,12 @@ final class RunParameterValidationRule implements Rule
             ];
         }
 
+        // Unpacking hides both the argument count and the positions the remaining
+        // arguments land on, so neither check can be made.
+        if ($this->helper->hasUnpackedArg($node->getArgs())) {
+            return [];
+        }
+
         $callArgCount = count($node->getArgs());
         $isConditional = $methodName === 'runIf' || $methodName === 'runUnless';
 

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -56,10 +56,7 @@ final class RunParameterValidationRule implements Rule
             ];
         }
 
-        $args = $node->getArgs();
-        if ($methodName === 'runIf' || $methodName === 'runUnless') {
-            $args = array_slice($args, 1);
-        }
+        $args = $this->helper->stripConditionArg($node->getArgs(), $methodName);
 
         $variant = ParametersAcceptorSelector::selectFromArgs(
             $scope,

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -32,15 +32,17 @@ final class RunParameterValidationRule implements Rule
     /** @return list<\PHPStan\Rules\IdentifierRuleError> */
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof StaticCall);
-
         $classReflection = $this->helper->resolveActionClass($node, $scope);
 
         if ($classReflection === null) {
             return [];
         }
 
-        $methodName = $node->name->toString();
+        $methodName = $this->helper->resolveProxyMethodName($node);
+
+        if ($methodName === null) {
+            return [];
+        }
 
         $handleMethod = $this->helper->getHandleMethod($classReflection);
 

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -21,7 +21,8 @@ final class RunParameterValidationRule implements Rule
     public function __construct(
         private ActionHelper $helper,
         private RuleLevelHelper $ruleLevelHelper,
-    ) {}
+    ) {
+    }
 
     public function getNodeType(): string
     {
@@ -120,7 +121,22 @@ final class RunParameterValidationRule implements Rule
         }
 
         foreach ($args as $i => $arg) {
-            $param = $parameters[$i] ?? ($isVariadic ? $parameters[count($parameters) - 1] : null);
+            if ($arg->name !== null) {
+                $paramName = $arg->name->toString();
+                $param = null;
+                $paramIndex = null;
+                foreach ($parameters as $j => $p) {
+                    if ($p->getName() === $paramName) {
+                        $param = $p;
+                        $paramIndex = $j;
+
+                        break;
+                    }
+                }
+            } else {
+                $param = $parameters[$i] ?? ($isVariadic ? $parameters[count($parameters) - 1] : null);
+                $paramIndex = $i;
+            }
 
             if ($param === null) {
                 continue;
@@ -132,9 +148,11 @@ final class RunParameterValidationRule implements Rule
             $accepts = $this->ruleLevelHelper->accepts($paramType, $argType, $scope->isDeclareStrictTypes());
 
             if (! $accepts->result) {
+                $reportedIndex = $isConditional ? ($paramIndex ?? $i) + 2 : ($paramIndex ?? $i) + 1;
+
                 $errors[] = RuleErrorBuilder::message(sprintf(
                     'Parameter #%d $%s of %s::%s() expects %s, %s given.',
-                    $isConditional ? $i + 2 : $i + 1,
+                    $reportedIndex,
                     $param->getName(),
                     $classReflection->getDisplayName(),
                     $methodName,

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -56,6 +56,9 @@ final class RunParameterValidationRule implements Rule
             ];
         }
 
+        $callArgCount = count($node->getArgs());
+        $isConditional = $methodName === 'runIf' || $methodName === 'runUnless';
+
         $args = $this->helper->stripConditionArg($node->getArgs(), $methodName);
 
         $variant = ParametersAcceptorSelector::selectFromArgs(
@@ -76,12 +79,10 @@ final class RunParameterValidationRule implements Rule
             }
         }
 
-        $isConditional = $methodName === 'runIf' || $methodName === 'runUnless';
         $maxParams = $isVariadic ? null : count($parameters);
         $argCount = count($args);
 
         // Report counts relative to the actual call (including the condition argument for runIf/runUnless).
-        $reportedArgCount = $isConditional ? $argCount + 1 : $argCount;
         $reportedMin = $isConditional ? $minParams + 1 : $minParams;
         $reportedMax = $maxParams !== null ? ($isConditional ? $maxParams + 1 : $maxParams) : null;
 
@@ -94,7 +95,7 @@ final class RunParameterValidationRule implements Rule
                     $reportedMin === $reportedMax ? 'exactly' : 'at least',
                     $reportedMin,
                     $reportedMin === 1 ? 'argument' : 'arguments',
-                    $reportedArgCount,
+                    $callArgCount,
                 ))
                     ->identifier('laravelActions.tooFewArguments')
                     ->build(),
@@ -110,7 +111,7 @@ final class RunParameterValidationRule implements Rule
                     $reportedMin === $reportedMax ? 'exactly' : 'at most',
                     $reportedMax,
                     $reportedMax === 1 ? 'argument' : 'arguments',
-                    $reportedArgCount,
+                    $callArgCount,
                 ))
                     ->identifier('laravelActions.tooManyArguments')
                     ->build(),

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements Rule<StaticCall>
+ */
+final class RunParameterValidationRule implements Rule
+{
+    public function __construct(
+        private ActionHelper $helper,
+        private RuleLevelHelper $ruleLevelHelper,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /** @return list<\PHPStan\Rules\IdentifierRuleError> */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof StaticCall);
+
+        $classReflection = $this->helper->resolveActionClass($node, $scope);
+
+        if ($classReflection === null) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        $handleMethod = $this->helper->getHandleMethod($classReflection);
+
+        if ($handleMethod === null) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Call to %s::%s() but class has no handle() method.',
+                    $classReflection->getDisplayName(),
+                    $methodName,
+                ))
+                    ->identifier('laravelActions.missingHandle')
+                    ->build(),
+            ];
+        }
+
+        $args = $node->getArgs();
+        if ($methodName === 'runIf' || $methodName === 'runUnless') {
+            $args = array_slice($args, 1);
+        }
+
+        $variant = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $args,
+            $handleMethod->getVariants(),
+            $handleMethod->getNamedArgumentsVariants(),
+        );
+
+        $parameters = $variant->getParameters();
+        $isVariadic = $variant->isVariadic();
+        $errors = [];
+
+        $minParams = 0;
+        foreach ($parameters as $param) {
+            if (! $param->isOptional()) {
+                $minParams++;
+            }
+        }
+
+        $isConditional = $methodName === 'runIf' || $methodName === 'runUnless';
+        $maxParams = $isVariadic ? null : count($parameters);
+        $argCount = count($args);
+
+        // Report counts relative to the actual call (including the condition argument for runIf/runUnless).
+        $reportedArgCount = $isConditional ? $argCount + 1 : $argCount;
+        $reportedMin = $isConditional ? $minParams + 1 : $minParams;
+        $reportedMax = $maxParams !== null ? ($isConditional ? $maxParams + 1 : $maxParams) : null;
+
+        if ($argCount < $minParams) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    '%s::%s() expects %s %d %s, %d given.',
+                    $classReflection->getDisplayName(),
+                    $methodName,
+                    $reportedMin === $reportedMax ? 'exactly' : 'at least',
+                    $reportedMin,
+                    $reportedMin === 1 ? 'argument' : 'arguments',
+                    $reportedArgCount,
+                ))
+                    ->identifier('laravelActions.tooFewArguments')
+                    ->build(),
+            ];
+        }
+
+        if ($maxParams !== null && $argCount > $maxParams) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    '%s::%s() expects %s %d %s, %d given.',
+                    $classReflection->getDisplayName(),
+                    $methodName,
+                    $reportedMin === $reportedMax ? 'exactly' : 'at most',
+                    $reportedMax,
+                    $reportedMax === 1 ? 'argument' : 'arguments',
+                    $reportedArgCount,
+                ))
+                    ->identifier('laravelActions.tooManyArguments')
+                    ->build(),
+            ];
+        }
+
+        foreach ($args as $i => $arg) {
+            $param = $parameters[$i] ?? ($isVariadic ? $parameters[count($parameters) - 1] : null);
+
+            if ($param === null) {
+                continue;
+            }
+
+            $argType = $scope->getType($arg->value);
+            $paramType = $param->getType();
+
+            $accepts = $this->ruleLevelHelper->accepts($paramType, $argType, $scope->isDeclareStrictTypes());
+
+            if (! $accepts->result) {
+                $errors[] = RuleErrorBuilder::message(sprintf(
+                    'Parameter #%d $%s of %s::%s() expects %s, %s given.',
+                    $isConditional ? $i + 2 : $i + 1,
+                    $param->getName(),
+                    $classReflection->getDisplayName(),
+                    $methodName,
+                    $paramType->describe(VerbosityLevel::typeOnly()),
+                    $argType->describe(VerbosityLevel::typeOnly()),
+                ))
+                    ->identifier('laravelActions.argumentType')
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -50,6 +50,11 @@ final class RunParameterValidationRule implements Rule
                 return [];
             }
 
+            // A subclass receiving the call may declare handle() itself.
+            if ($this->helper->isLateStaticBinding($node)) {
+                return [];
+            }
+
             return [
                 RuleErrorBuilder::message(sprintf(
                     'Call to %s::%s() but class has no handle() method.',

--- a/src/PHPStan/RunParameterValidationRule.php
+++ b/src/PHPStan/RunParameterValidationRule.php
@@ -45,6 +45,11 @@ final class RunParameterValidationRule implements Rule
         $handleMethod = $this->helper->getHandleMethod($classReflection);
 
         if ($handleMethod === null) {
+            // A virtual handle() has an unknown signature rather than a missing one.
+            if ($classReflection->hasMethod('handle')) {
+                return [];
+            }
+
             return [
                 RuleErrorBuilder::message(sprintf(
                     'Call to %s::%s() but class has no handle() method.',

--- a/src/PHPStan/RunReturnTypeExtension.php
+++ b/src/PHPStan/RunReturnTypeExtension.php
@@ -39,7 +39,11 @@ final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
             return null;
         }
 
-        $methodName = $expr->name->toString();
+        $methodName = $this->helper->resolveProxyMethodName($expr);
+
+        if ($methodName === null) {
+            return null;
+        }
 
         $conditionArg = $this->helper->getConditionArg($expr->getArgs(), $methodName);
         $args = $this->helper->stripConditionArg($expr->getArgs(), $methodName);

--- a/src/PHPStan/RunReturnTypeExtension.php
+++ b/src/PHPStan/RunReturnTypeExtension.php
@@ -17,7 +17,8 @@ final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
 {
     public function __construct(
         private ActionHelper $helper,
-    ) {}
+    ) {
+    }
 
     public function getType(Expr $expr, Scope $scope): ?Type
     {

--- a/src/PHPStan/RunReturnTypeExtension.php
+++ b/src/PHPStan/RunReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ExpressionTypeResolverExtension;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -72,6 +73,12 @@ final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
             }
         }
 
-        return TypeCombinator::union($handleReturnType, $fluentType);
+        // void cannot take part in a union, and a void handle() leaves the call
+        // evaluating to null.
+        $valueType = $handleReturnType->isVoid()->yes()
+            ? new NullType()
+            : $handleReturnType;
+
+        return TypeCombinator::union($valueType, $fluentType);
     }
 }

--- a/src/PHPStan/RunReturnTypeExtension.php
+++ b/src/PHPStan/RunReturnTypeExtension.php
@@ -40,6 +40,7 @@ final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
 
         $methodName = $expr->name->toString();
 
+        $conditionArg = $this->helper->getConditionArg($expr->getArgs(), $methodName);
         $args = $this->helper->stripConditionArg($expr->getArgs(), $methodName);
 
         $variant = ParametersAcceptorSelector::selectFromArgs(
@@ -55,9 +56,22 @@ final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
             return $handleReturnType;
         }
 
-        return TypeCombinator::union(
-            $handleReturnType,
-            new ObjectType('Illuminate\Support\Fluent'),
-        );
+        $fluentType = new ObjectType('Illuminate\Support\Fluent');
+
+        if ($conditionArg !== null) {
+            $conditionType = $scope->getType($conditionArg->value);
+            $runsHandle = $methodName === 'runIf' ? $conditionType->isTrue() : $conditionType->isFalse();
+            $skipsHandle = $methodName === 'runIf' ? $conditionType->isFalse() : $conditionType->isTrue();
+
+            if ($runsHandle->yes()) {
+                return $handleReturnType;
+            }
+
+            if ($skipsHandle->yes()) {
+                return $fluentType;
+            }
+        }
+
+        return TypeCombinator::union($handleReturnType, $fluentType);
     }
 }

--- a/src/PHPStan/RunReturnTypeExtension.php
+++ b/src/PHPStan/RunReturnTypeExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\PHPStan;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ExpressionTypeResolverExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
+{
+    public function __construct(
+        private ActionHelper $helper,
+    ) {}
+
+    public function getType(Expr $expr, Scope $scope): ?Type
+    {
+        if (! $expr instanceof StaticCall) {
+            return null;
+        }
+
+        $classReflection = $this->helper->resolveActionClass($expr, $scope);
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $handleMethod = $this->helper->getHandleMethod($classReflection);
+
+        if ($handleMethod === null) {
+            return null;
+        }
+
+        $methodName = $expr->name->toString();
+
+        $args = $expr->getArgs();
+        if ($methodName === 'runIf' || $methodName === 'runUnless') {
+            $args = array_slice($args, 1);
+        }
+
+        $variant = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $args,
+            $handleMethod->getVariants(),
+            $handleMethod->getNamedArgumentsVariants(),
+        );
+
+        $handleReturnType = $variant->getReturnType();
+
+        if ($methodName === 'run') {
+            return $handleReturnType;
+        }
+
+        return TypeCombinator::union(
+            $handleReturnType,
+            new ObjectType('Illuminate\Support\Fluent'),
+        );
+    }
+}

--- a/src/PHPStan/RunReturnTypeExtension.php
+++ b/src/PHPStan/RunReturnTypeExtension.php
@@ -40,10 +40,7 @@ final class RunReturnTypeExtension implements ExpressionTypeResolverExtension
 
         $methodName = $expr->name->toString();
 
-        $args = $expr->getArgs();
-        if ($methodName === 'runIf' || $methodName === 'runUnless') {
-            $args = array_slice($args, 1);
-        }
+        $args = $this->helper->stripConditionArg($expr->getArgs(), $methodName);
 
         $variant = ParametersAcceptorSelector::selectFromArgs(
             $scope,

--- a/src/PHPStan/RunThrowTypeExtension.php
+++ b/src/PHPStan/RunThrowTypeExtension.php
@@ -8,22 +8,21 @@ use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use Throwable;
 
 final class RunThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
 {
     public function __construct(
         private ActionHelper $helper,
+        private bool $implicitThrows,
     ) {
     }
 
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool
     {
-        return in_array(
-            $methodReflection->getName(),
-            ['run', 'runIf', 'runUnless'],
-            true,
-        );
+        return $this->helper->isActionProxyMethod($methodReflection);
     }
 
     public function getThrowTypeFromStaticMethodCall(
@@ -33,16 +32,20 @@ final class RunThrowTypeExtension implements DynamicStaticMethodThrowTypeExtensi
     ): ?Type {
         $classReflection = $this->helper->resolveActionClass($methodCall, $scope);
 
-        if ($classReflection === null) {
-            return null;
-        }
+        $handleMethod = $classReflection === null
+            ? null
+            : $this->helper->getHandleMethod($classReflection);
 
-        $handleMethod = $this->helper->getHandleMethod($classReflection);
+        return $handleMethod?->getThrowType() ?? $this->implicitThrowType();
+    }
 
-        if ($handleMethod === null) {
-            return null;
-        }
-
-        return $handleMethod->getThrowType();
+    /**
+     * PHPStan reads a null throw type as "throws nothing", so anything this
+     * extension cannot determine has to fall back to what PHPStan would infer
+     * for run() on its own.
+     */
+    private function implicitThrowType(): ?Type
+    {
+        return $this->implicitThrows ? new ObjectType(Throwable::class) : null;
     }
 }

--- a/src/PHPStan/RunThrowTypeExtension.php
+++ b/src/PHPStan/RunThrowTypeExtension.php
@@ -14,7 +14,8 @@ final class RunThrowTypeExtension implements DynamicStaticMethodThrowTypeExtensi
 {
     public function __construct(
         private ActionHelper $helper,
-    ) {}
+    ) {
+    }
 
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool
     {

--- a/src/PHPStan/RunThrowTypeExtension.php
+++ b/src/PHPStan/RunThrowTypeExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\PHPStan;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\Type;
+
+final class RunThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+    public function __construct(
+        private ActionHelper $helper,
+    ) {}
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array(
+            $methodReflection->getName(),
+            ['run', 'runIf', 'runUnless'],
+            true,
+        );
+    }
+
+    public function getThrowTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        $classReflection = $this->helper->resolveActionClass($methodCall, $scope);
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $handleMethod = $this->helper->getHandleMethod($classReflection);
+
+        if ($handleMethod === null) {
+            return null;
+        }
+
+        return $handleMethod->getThrowType();
+    }
+}

--- a/tests/PHPStan/Fixtures/run-implicit-throw-types.php
+++ b/tests/PHPStan/Fixtures/run-implicit-throw-types.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan\Fixtures;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class ImplicitThrowAction
+{
+    use AsAction;
+
+    public function handle(): int
+    {
+        throw new RuntimeException('No @throws tag');
+    }
+}
+
+class ImplicitThrowNonAction
+{
+    public static function run(): int
+    {
+        throw new RuntimeException('Not an action');
+    }
+}
+
+// None of these catches are dead: run() throws whatever handle() throws.
+function catchImplicitAction(): void
+{
+    try {
+        ImplicitThrowAction::run();
+    } catch (RuntimeException $e) {
+    }
+}
+
+function catchImplicitActionRunIf(bool $flag): void
+{
+    try {
+        ImplicitThrowAction::runIf($flag);
+    } catch (RuntimeException $e) {
+    }
+}
+
+function catchImplicitNonAction(): void
+{
+    try {
+        ImplicitThrowNonAction::run();
+    } catch (RuntimeException $e) {
+    }
+}

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -124,6 +124,15 @@ function wrongNamedArgumentTypes(): void
     NamedArgAction::run(a: 'not-int');
 }
 
+function unknownNamedArguments(): void
+{
+    NamedArgAction::run(a: 1, typo: 2);
+    NamedArgAction::runIf(true, a: 1, typo: 2);
+
+    // A variadic handle() accepts any name.
+    VariadicAction::run(anything: 'a');
+}
+
 function namedConditionArgument(): void
 {
     AddAction::runIf(a: 1, b: 2, boolean: true);

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -188,3 +188,22 @@ function unpackedArguments(array $pair, array $all): void
     AddAction::runIf(...$all);
     NoHandleAction::run(...$pair);
 }
+
+abstract class BaseAction
+{
+    use AsAction;
+
+    public static function twice(): void
+    {
+        static::run();
+        static::run();
+    }
+}
+
+final class ConcreteAction extends BaseAction
+{
+    public function handle(): int
+    {
+        return 1;
+    }
+}

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -175,3 +175,16 @@ function annotatedHandle(): void
     AnnotatedHandleAction::run();
     AnnotatedHandleAction::runIf(true, 'hello');
 }
+
+/**
+ * @param array{int, int} $pair
+ * @param array{bool, int, int} $all
+ */
+function unpackedArguments(array $pair, array $all): void
+{
+    AddAction::run(...$pair);
+    AddAction::runIf(true, ...$pair);
+    AddAction::runUnless(false, ...$pair);
+    AddAction::runIf(...$all);
+    NoHandleAction::run(...$pair);
+}

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan\Fixtures;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\AsObject;
+
+class AddAction
+{
+    use AsAction;
+
+    public function handle(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+class NoHandleAction
+{
+    use AsAction;
+}
+
+class VariadicAction
+{
+    use AsAction;
+
+    public function handle(string ...$names): string
+    {
+        return implode(', ', $names);
+    }
+}
+
+class OptionalAction
+{
+    use AsAction;
+
+    public function handle(int $a, int $b = 0): int
+    {
+        return $a + $b;
+    }
+}
+
+// Valid calls — no errors expected
+AddAction::run(1, 2);
+AddAction::runIf(true, 1, 2);
+AddAction::runUnless(false, 1, 2);
+VariadicAction::run('a', 'b', 'c');
+VariadicAction::run();
+OptionalAction::run(1);
+OptionalAction::run(1, 2);
+
+// Too few arguments
+AddAction::run();
+AddAction::run(1);
+AddAction::runIf(true);
+AddAction::runUnless(false, 1);
+
+// Too many arguments
+AddAction::run(1, 2, 3);
+
+// Wrong argument types
+AddAction::run('not-int', 2);
+AddAction::run(1, 'not-int');
+OptionalAction::run('not-int');
+
+// No handle method
+NoHandleAction::run();
+NoHandleAction::runIf(true);

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -61,6 +61,18 @@ class NoParamsAction
     }
 }
 
+/** @method string handle(string $input) */
+class AnnotatedHandleAction
+{
+    use AsAction;
+
+    /** @param array<mixed> $arguments */
+    public function __call(string $name, array $arguments): string
+    {
+        return 'ran';
+    }
+}
+
 function validCalls(): void
 {
     AddAction::run(1, 2);
@@ -130,15 +142,13 @@ function zeroArgumentConditional(): void
 
 function conditionalWithoutParameters(): void
 {
-    // Valid, the condition is the only argument.
     NoParamsAction::runIf(true);
     NoParamsAction::runUnless(false);
 
-    // Zero-arg. This rule stays silent, PHPStan's native check reports the missing $boolean.
+    // This rule stays silent on zero-arg calls, PHPStan's native check reports the missing $boolean.
     NoParamsAction::runIf();
     NoParamsAction::runUnless();
 
-    // Too many arguments.
     NoParamsAction::runIf(true, 'extra');
 }
 
@@ -147,4 +157,21 @@ function variadicConditional(): void
 {
     VariadicAction::runIf(true);
     VariadicAction::runIf(true, 'a', 'b');
+}
+
+function firstClassCallables(): void
+{
+    $run = AddAction::run(...);
+    $runIf = AddAction::runIf(...);
+    $runUnless = AddAction::runUnless(...);
+    $run(1, 2);
+    $runIf(true, 1, 2);
+    $runUnless(false, 1, 2);
+}
+
+function annotatedHandle(): void
+{
+    AnnotatedHandleAction::run('hello');
+    AnnotatedHandleAction::run();
+    AnnotatedHandleAction::runIf(true, 'hello');
 }

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -89,3 +89,7 @@ NamedArgAction::runIf(true, 1, c: 3.14);
 // Wrong type via named argument — should error
 NamedArgAction::run(1, c: 'not-float');
 NamedArgAction::run(a: 'not-int');
+
+// Named condition argument
+AddAction::runIf(a: 1, b: 2, boolean: true);
+AddAction::runIf(a: 'not-int', b: 2, boolean: true);

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -93,3 +93,34 @@ NamedArgAction::run(a: 'not-int');
 // Named condition argument
 AddAction::runIf(a: 1, b: 2, boolean: true);
 AddAction::runIf(a: 'not-int', b: 2, boolean: true);
+
+// Zero-arg conditional call — always fatal at runtime, reported with the full arity
+AddAction::runIf();
+AddAction::runUnless();
+
+// --- Conditional calls on a handle() with no parameters ---
+
+class NoParamsAction
+{
+    use AsAction;
+
+    public function handle(): string
+    {
+        return 'ran';
+    }
+}
+
+// Valid — the condition is the only argument
+NoParamsAction::runIf(true);
+NoParamsAction::runUnless(false);
+
+// Zero-arg — this rule stays silent, PHPStan's native check reports the missing $boolean
+NoParamsAction::runIf();
+NoParamsAction::runUnless();
+
+// Too many arguments
+NoParamsAction::runIf(true, 'extra');
+
+// Variadic handle() called conditionally — any number of arguments is valid
+VariadicAction::runIf(true);
+VariadicAction::runIf(true, 'a', 'b');

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -41,35 +41,6 @@ class OptionalAction
     }
 }
 
-// Valid calls — no errors expected
-AddAction::run(1, 2);
-AddAction::runIf(true, 1, 2);
-AddAction::runUnless(false, 1, 2);
-VariadicAction::run('a', 'b', 'c');
-VariadicAction::run();
-OptionalAction::run(1);
-OptionalAction::run(1, 2);
-
-// Too few arguments
-AddAction::run();
-AddAction::run(1);
-AddAction::runIf(true);
-AddAction::runUnless(false, 1);
-
-// Too many arguments
-AddAction::run(1, 2, 3);
-
-// Wrong argument types
-AddAction::run('not-int', 2);
-AddAction::run(1, 'not-int');
-OptionalAction::run('not-int');
-
-// No handle method
-NoHandleAction::run();
-NoHandleAction::runIf(true);
-
-// --- Named arguments ---
-
 class NamedArgAction
 {
     use AsAction;
@@ -79,26 +50,6 @@ class NamedArgAction
         return "$a $b $c";
     }
 }
-
-// Valid named argument calls — no errors
-NamedArgAction::run(1, c: 3.14);
-NamedArgAction::run(a: 1, c: 3.14);
-NamedArgAction::run(a: 1, b: 'hello', c: 3.14);
-NamedArgAction::runIf(true, 1, c: 3.14);
-
-// Wrong type via named argument — should error
-NamedArgAction::run(1, c: 'not-float');
-NamedArgAction::run(a: 'not-int');
-
-// Named condition argument
-AddAction::runIf(a: 1, b: 2, boolean: true);
-AddAction::runIf(a: 'not-int', b: 2, boolean: true);
-
-// Zero-arg conditional call — always fatal at runtime, reported with the full arity
-AddAction::runIf();
-AddAction::runUnless();
-
-// --- Conditional calls on a handle() with no parameters ---
 
 class NoParamsAction
 {
@@ -110,17 +61,90 @@ class NoParamsAction
     }
 }
 
-// Valid — the condition is the only argument
-NoParamsAction::runIf(true);
-NoParamsAction::runUnless(false);
+function validCalls(): void
+{
+    AddAction::run(1, 2);
+    AddAction::runIf(true, 1, 2);
+    AddAction::runUnless(false, 1, 2);
+    VariadicAction::run('a', 'b', 'c');
+    VariadicAction::run();
+    OptionalAction::run(1);
+    OptionalAction::run(1, 2);
+}
 
-// Zero-arg — this rule stays silent, PHPStan's native check reports the missing $boolean
-NoParamsAction::runIf();
-NoParamsAction::runUnless();
+function tooFewArguments(): void
+{
+    AddAction::run();
+    AddAction::run(1);
+    AddAction::runIf(true);
+    AddAction::runUnless(false, 1);
+}
 
-// Too many arguments
-NoParamsAction::runIf(true, 'extra');
+function tooManyArguments(): void
+{
+    AddAction::run(1, 2, 3);
+}
 
-// Variadic handle() called conditionally — any number of arguments is valid
-VariadicAction::runIf(true);
-VariadicAction::runIf(true, 'a', 'b');
+function wrongArgumentTypes(): void
+{
+    AddAction::run('not-int', 2);
+    AddAction::run(1, 'not-int');
+    OptionalAction::run('not-int');
+}
+
+function noHandleMethod(): void
+{
+    NoHandleAction::run();
+    NoHandleAction::runIf(true);
+}
+
+function validNamedArguments(): void
+{
+    NamedArgAction::run(1, c: 3.14);
+    NamedArgAction::run(a: 1, c: 3.14);
+    NamedArgAction::run(a: 1, b: 'hello', c: 3.14);
+    NamedArgAction::runIf(true, 1, c: 3.14);
+}
+
+function wrongNamedArgumentTypes(): void
+{
+    NamedArgAction::run(1, c: 'not-float');
+    NamedArgAction::run(a: 'not-int');
+}
+
+function namedConditionArgument(): void
+{
+    AddAction::runIf(a: 1, b: 2, boolean: true);
+    AddAction::runIf(a: 'not-int', b: 2, boolean: true);
+}
+
+/**
+ * Zero-arg conditional calls are always fatal at runtime, so they are reported
+ * with the full arity of the call, including the condition argument.
+ */
+function zeroArgumentConditional(): void
+{
+    AddAction::runIf();
+    AddAction::runUnless();
+}
+
+function conditionalWithoutParameters(): void
+{
+    // Valid, the condition is the only argument.
+    NoParamsAction::runIf(true);
+    NoParamsAction::runUnless(false);
+
+    // Zero-arg. This rule stays silent, PHPStan's native check reports the missing $boolean.
+    NoParamsAction::runIf();
+    NoParamsAction::runUnless();
+
+    // Too many arguments.
+    NoParamsAction::runIf(true, 'extra');
+}
+
+/** A variadic handle() called conditionally accepts any number of arguments. */
+function variadicConditional(): void
+{
+    VariadicAction::runIf(true);
+    VariadicAction::runIf(true, 'a', 'b');
+}

--- a/tests/PHPStan/Fixtures/run-parameter-validation.php
+++ b/tests/PHPStan/Fixtures/run-parameter-validation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lorisleiva\Actions\Tests\PHPStan\Fixtures;
 
 use Lorisleiva\Actions\Concerns\AsAction;
-use Lorisleiva\Actions\Concerns\AsObject;
 
 class AddAction
 {
@@ -68,3 +67,25 @@ OptionalAction::run('not-int');
 // No handle method
 NoHandleAction::run();
 NoHandleAction::runIf(true);
+
+// --- Named arguments ---
+
+class NamedArgAction
+{
+    use AsAction;
+
+    public function handle(int $a, string $b = 'default', float $c = 0.0): string
+    {
+        return "$a $b $c";
+    }
+}
+
+// Valid named argument calls — no errors
+NamedArgAction::run(1, c: 3.14);
+NamedArgAction::run(a: 1, c: 3.14);
+NamedArgAction::run(a: 1, b: 'hello', c: 3.14);
+NamedArgAction::runIf(true, 1, c: 3.14);
+
+// Wrong type via named argument — should error
+NamedArgAction::run(1, c: 'not-float');
+NamedArgAction::run(a: 'not-int');

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -78,15 +78,24 @@ assertType('bool', AsObjectOnlyAction::run('test'));
 assertType('int', OptionalParamsAction::run(1, 2));
 assertType('int', OptionalParamsAction::run(1, 2, false));
 
-// runIf() return types — union with Fluent
-assertType('Illuminate\Support\Fluent|int', IntAction::runIf(true, 1, 2));
-assertType('Illuminate\Support\Fluent|void', VoidAction::runIf(true, 'hello'));
-assertType('Illuminate\Support\Fluent|string|null', NullableAction::runIf(true));
-assertType('Illuminate\Support\Fluent|int|string', UnionReturnAction::runIf(true));
+// runIf() return types — narrowed when the condition is a literal true/false
+assertType('int', IntAction::runIf(true, 1, 2));
+assertType('void', VoidAction::runIf(true, 'hello'));
+assertType('string|null', NullableAction::runIf(true));
+assertType('int|string', UnionReturnAction::runIf(true));
+assertType('Illuminate\Support\Fluent', IntAction::runIf(false, 1, 2));
 
-// runUnless() return types — same as runIf
-assertType('Illuminate\Support\Fluent|int', IntAction::runUnless(false, 1, 2));
-assertType('bool|Illuminate\Support\Fluent', AsObjectOnlyAction::runUnless(false, 'test'));
+// runUnless() return types — same as runIf, inverted
+assertType('int', IntAction::runUnless(false, 1, 2));
+assertType('bool', AsObjectOnlyAction::runUnless(false, 'test'));
+assertType('Illuminate\Support\Fluent', IntAction::runUnless(true, 1, 2));
+
+// runIf()/runUnless() return types — union with Fluent when the condition isn't statically known
+function withVariableCondition(bool $flag): void
+{
+    assertType('Illuminate\Support\Fluent|int', IntAction::runIf($flag, 1, 2));
+    assertType('Illuminate\Support\Fluent|int', IntAction::runUnless($flag, 1, 2));
+}
 
 // run() via a class-string variable
 /** @var class-string<IntAction> $actionClass */

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -79,7 +79,7 @@ function runReturnTypes(): void
     assertType('int', OptionalParamsAction::run(1, 2, false));
 }
 
-/** runIf() is narrowed when the condition is a literal true/false. */
+/** runIf() narrows to handle()'s return type when the condition is a literal true/false. */
 function runIfReturnTypes(): void
 {
     assertType('int', IntAction::runIf(true, 1, 2));
@@ -89,7 +89,6 @@ function runIfReturnTypes(): void
     assertType('Illuminate\Support\Fluent', IntAction::runIf(false, 1, 2));
 }
 
-/** runUnless() behaves the same as runIf(), inverted. */
 function runUnlessReturnTypes(): void
 {
     assertType('int', IntAction::runUnless(false, 1, 2));

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan\Fixtures;
+
+use Illuminate\Support\Fluent;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Lorisleiva\Actions\Concerns\AsObject;
+
+use function PHPStan\Testing\assertType;
+
+class IntAction
+{
+    use AsAction;
+
+    public function handle(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+
+class VoidAction
+{
+    use AsAction;
+
+    public function handle(string $name): void {}
+}
+
+class NullableAction
+{
+    use AsAction;
+
+    public function handle(): ?string
+    {
+        return null;
+    }
+}
+
+class UnionReturnAction
+{
+    use AsAction;
+
+    public function handle(): int|string
+    {
+        return 1;
+    }
+}
+
+class AsObjectOnlyAction
+{
+    use AsObject;
+
+    public function handle(string $input): bool
+    {
+        return $input !== '';
+    }
+}
+
+class OptionalParamsAction
+{
+    use AsAction;
+
+    public function handle(int $a, int $b, bool $addition = true): int
+    {
+        return $addition ? $a + $b : $a - $b;
+    }
+}
+
+// run() return types
+assertType('int', IntAction::run(1, 2));
+assertType('void', VoidAction::run('hello'));
+assertType('string|null', NullableAction::run());
+assertType('int|string', UnionReturnAction::run());
+assertType('bool', AsObjectOnlyAction::run('test'));
+assertType('int', OptionalParamsAction::run(1, 2));
+assertType('int', OptionalParamsAction::run(1, 2, false));
+
+// runIf() return types — union with Fluent
+assertType('Illuminate\Support\Fluent|int', IntAction::runIf(true, 1, 2));
+assertType('Illuminate\Support\Fluent|void', VoidAction::runIf(true, 'hello'));
+assertType('Illuminate\Support\Fluent|string|null', NullableAction::runIf(true));
+assertType('Illuminate\Support\Fluent|int|string', UnionReturnAction::runIf(true));
+
+// runUnless() return types — same as runIf
+assertType('Illuminate\Support\Fluent|int', IntAction::runUnless(false, 1, 2));
+assertType('bool|Illuminate\Support\Fluent', AsObjectOnlyAction::runUnless(false, 'test'));

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -24,7 +24,9 @@ class VoidAction
 {
     use AsAction;
 
-    public function handle(string $name): void {}
+    public function handle(string $name): void
+    {
+    }
 }
 
 class NullableAction

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lorisleiva\Actions\Tests\PHPStan\Fixtures;
 
-use Illuminate\Support\Fluent;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Lorisleiva\Actions\Concerns\AsObject;
 
@@ -69,35 +68,45 @@ class OptionalParamsAction
     }
 }
 
-// run() return types
-assertType('int', IntAction::run(1, 2));
-assertType('void', VoidAction::run('hello'));
-assertType('string|null', NullableAction::run());
-assertType('int|string', UnionReturnAction::run());
-assertType('bool', AsObjectOnlyAction::run('test'));
-assertType('int', OptionalParamsAction::run(1, 2));
-assertType('int', OptionalParamsAction::run(1, 2, false));
+function runReturnTypes(): void
+{
+    assertType('int', IntAction::run(1, 2));
+    assertType('void', VoidAction::run('hello'));
+    assertType('string|null', NullableAction::run());
+    assertType('int|string', UnionReturnAction::run());
+    assertType('bool', AsObjectOnlyAction::run('test'));
+    assertType('int', OptionalParamsAction::run(1, 2));
+    assertType('int', OptionalParamsAction::run(1, 2, false));
+}
 
-// runIf() return types — narrowed when the condition is a literal true/false
-assertType('int', IntAction::runIf(true, 1, 2));
-assertType('void', VoidAction::runIf(true, 'hello'));
-assertType('string|null', NullableAction::runIf(true));
-assertType('int|string', UnionReturnAction::runIf(true));
-assertType('Illuminate\Support\Fluent', IntAction::runIf(false, 1, 2));
+/** runIf() is narrowed when the condition is a literal true/false. */
+function runIfReturnTypes(): void
+{
+    assertType('int', IntAction::runIf(true, 1, 2));
+    assertType('void', VoidAction::runIf(true, 'hello'));
+    assertType('string|null', NullableAction::runIf(true));
+    assertType('int|string', UnionReturnAction::runIf(true));
+    assertType('Illuminate\Support\Fluent', IntAction::runIf(false, 1, 2));
+}
 
-// runUnless() return types — same as runIf, inverted
-assertType('int', IntAction::runUnless(false, 1, 2));
-assertType('bool', AsObjectOnlyAction::runUnless(false, 'test'));
-assertType('Illuminate\Support\Fluent', IntAction::runUnless(true, 1, 2));
+/** runUnless() behaves the same as runIf(), inverted. */
+function runUnlessReturnTypes(): void
+{
+    assertType('int', IntAction::runUnless(false, 1, 2));
+    assertType('bool', AsObjectOnlyAction::runUnless(false, 'test'));
+    assertType('Illuminate\Support\Fluent', IntAction::runUnless(true, 1, 2));
+}
 
-// runIf()/runUnless() return types — union with Fluent when the condition isn't statically known
+/** Both union with Fluent when the condition is not statically known. */
 function withVariableCondition(bool $flag): void
 {
     assertType('Illuminate\Support\Fluent|int', IntAction::runIf($flag, 1, 2));
     assertType('Illuminate\Support\Fluent|int', IntAction::runUnless($flag, 1, 2));
 }
 
-// run() via a class-string variable
-/** @var class-string<IntAction> $actionClass */
-$actionClass = IntAction::class;
-assertType('int', $actionClass::run(1, 2));
+function viaClassStringVariable(): void
+{
+    /** @var class-string<IntAction> $actionClass */
+    $actionClass = IntAction::class;
+    assertType('int', $actionClass::run(1, 2));
+}

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -101,6 +101,8 @@ function withVariableCondition(bool $flag): void
 {
     assertType('Illuminate\Support\Fluent|int', IntAction::runIf($flag, 1, 2));
     assertType('Illuminate\Support\Fluent|int', IntAction::runUnless($flag, 1, 2));
+    assertType('Illuminate\Support\Fluent|null', VoidAction::runIf($flag, 'hello'));
+    assertType('Illuminate\Support\Fluent|null', VoidAction::runUnless($flag, 'hello'));
 }
 
 function viaClassStringVariable(): void

--- a/tests/PHPStan/Fixtures/run-return-types.php
+++ b/tests/PHPStan/Fixtures/run-return-types.php
@@ -87,3 +87,8 @@ assertType('Illuminate\Support\Fluent|int|string', UnionReturnAction::runIf(true
 // runUnless() return types — same as runIf
 assertType('Illuminate\Support\Fluent|int', IntAction::runUnless(false, 1, 2));
 assertType('bool|Illuminate\Support\Fluent', AsObjectOnlyAction::runUnless(false, 'test'));
+
+// run() via a class-string variable
+/** @var class-string<IntAction> $actionClass */
+$actionClass = IntAction::class;
+assertType('int', $actionClass::run(1, 2));

--- a/tests/PHPStan/Fixtures/run-throw-types.php
+++ b/tests/PHPStan/Fixtures/run-throw-types.php
@@ -62,3 +62,19 @@ function callThrowingRunUnless(): void
 {
     ThrowingAction::runUnless(false, 'test');
 }
+
+/** A static run() on a class that is not an action keeps its own throw type. */
+class NotAnAction
+{
+    /** @throws RuntimeException */
+    public static function run(): int
+    {
+        throw new RuntimeException('Not an action');
+    }
+}
+
+// Should error: the extension leaves non-actions alone
+function callNonAction(): int
+{
+    return NotAnAction::run();
+}

--- a/tests/PHPStan/Fixtures/run-throw-types.php
+++ b/tests/PHPStan/Fixtures/run-throw-types.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan\Fixtures;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+use RuntimeException;
+
+class ThrowingAction
+{
+    use AsAction;
+
+    /** @throws RuntimeException */
+    public function handle(string $input): string
+    {
+        if ($input === '') {
+            throw new RuntimeException('Empty input');
+        }
+
+        return $input;
+    }
+}
+
+class NonThrowingAction
+{
+    use AsAction;
+
+    public function handle(): int
+    {
+        return 42;
+    }
+}
+
+// Should error: missing @throws
+function callThrowingWithoutDeclaring(): string
+{
+    return ThrowingAction::run('test');
+}
+
+// Should NOT error: @throws declared
+/** @throws RuntimeException */
+function callThrowingWithDeclaring(): string
+{
+    return ThrowingAction::run('test');
+}
+
+// Should NOT error: non-throwing action
+function callNonThrowing(): int
+{
+    return NonThrowingAction::run();
+}
+
+// Should error: runIf propagates throws
+function callThrowingRunIf(): void
+{
+    ThrowingAction::runIf(true, 'test');
+}
+
+// Should error: runUnless propagates throws
+function callThrowingRunUnless(): void
+{
+    ThrowingAction::runUnless(false, 'test');
+}

--- a/tests/PHPStan/RunImplicitThrowTypeExtensionTest.php
+++ b/tests/PHPStan/RunImplicitThrowTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan;
+
+use PHPStan\Rules\Exceptions\CatchWithUnthrownExceptionRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<CatchWithUnthrownExceptionRule> */
+final class RunImplicitThrowTypeExtensionTest extends RuleTestCase
+{
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/phpstan-implicit-throw-test.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(CatchWithUnthrownExceptionRule::class);
+    }
+
+    public function testImplicitThrowsAreNotSuppressed(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/run-implicit-throw-types.php'], []);
+    }
+}

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -82,6 +82,18 @@ final class RunParameterValidationRuleTest extends RuleTestCase
                 "Parameter #2 \$a of {$ns}\AddAction::runIf() expects int, string given.",
                 95,
             ],
+            [
+                "{$ns}\AddAction::runIf() expects exactly 3 arguments, 0 given.",
+                98,
+            ],
+            [
+                "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 0 given.",
+                99,
+            ],
+            [
+                "{$ns}\NoParamsAction::runIf() expects exactly 1 argument, 2 given.",
+                122,
+            ],
         ]);
     }
 }

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -94,6 +94,10 @@ final class RunParameterValidationRuleTest extends RuleTestCase
                 "{$ns}\NoParamsAction::runIf() expects exactly 1 argument, 2 given.",
                 152,
             ],
+            [
+                "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
+                189,
+            ],
         ]);
     }
 }

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan;
+
+use Lorisleiva\Actions\PHPStan\RunParameterValidationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<RunParameterValidationRule> */
+final class RunParameterValidationRuleTest extends RuleTestCase
+{
+    private const NS = 'Lorisleiva\Actions\Tests\PHPStan\Fixtures';
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/phpstan-test.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(RunParameterValidationRule::class);
+    }
+
+    public function testParameterValidation(): void
+    {
+        $ns = self::NS;
+
+        $this->analyse([__DIR__ . '/Fixtures/run-parameter-validation.php'], [
+            [
+                "{$ns}\AddAction::run() expects exactly 2 arguments, 0 given.",
+                55,
+            ],
+            [
+                "{$ns}\AddAction::run() expects exactly 2 arguments, 1 given.",
+                56,
+            ],
+            [
+                "{$ns}\AddAction::runIf() expects exactly 3 arguments, 1 given.",
+                57,
+            ],
+            [
+                "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 2 given.",
+                58,
+            ],
+            [
+                "{$ns}\AddAction::run() expects exactly 2 arguments, 3 given.",
+                61,
+            ],
+            [
+                "Parameter #1 \$a of {$ns}\AddAction::run() expects int, string given.",
+                64,
+            ],
+            [
+                "Parameter #2 \$b of {$ns}\AddAction::run() expects int, string given.",
+                65,
+            ],
+            [
+                "Parameter #1 \$a of {$ns}\OptionalAction::run() expects int, string given.",
+                66,
+            ],
+            [
+                "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
+                69,
+            ],
+            [
+                "Call to {$ns}\NoHandleAction::runIf() but class has no handle() method.",
+                70,
+            ],
+        ]);
+    }
+}

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -31,68 +31,68 @@ final class RunParameterValidationRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/Fixtures/run-parameter-validation.php'], [
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 0 given.",
-                77,
+                89,
             ],
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 1 given.",
-                78,
-            ],
-            [
-                "{$ns}\AddAction::runIf() expects exactly 3 arguments, 1 given.",
-                79,
-            ],
-            [
-                "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 2 given.",
-                80,
-            ],
-            [
-                "{$ns}\AddAction::run() expects exactly 2 arguments, 3 given.",
-                85,
-            ],
-            [
-                "Parameter #1 \$a of {$ns}\AddAction::run() expects int, string given.",
                 90,
             ],
             [
-                "Parameter #2 \$b of {$ns}\AddAction::run() expects int, string given.",
+                "{$ns}\AddAction::runIf() expects exactly 3 arguments, 1 given.",
                 91,
             ],
             [
-                "Parameter #1 \$a of {$ns}\OptionalAction::run() expects int, string given.",
+                "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 2 given.",
                 92,
             ],
             [
-                "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
+                "{$ns}\AddAction::run() expects exactly 2 arguments, 3 given.",
                 97,
             ],
             [
+                "Parameter #1 \$a of {$ns}\AddAction::run() expects int, string given.",
+                102,
+            ],
+            [
+                "Parameter #2 \$b of {$ns}\AddAction::run() expects int, string given.",
+                103,
+            ],
+            [
+                "Parameter #1 \$a of {$ns}\OptionalAction::run() expects int, string given.",
+                104,
+            ],
+            [
+                "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
+                109,
+            ],
+            [
                 "Call to {$ns}\NoHandleAction::runIf() but class has no handle() method.",
-                98,
+                110,
             ],
             // Named argument type errors
             [
                 "Parameter #3 \$c of {$ns}\NamedArgAction::run() expects float, string given.",
-                111,
+                123,
             ],
             [
                 "Parameter #1 \$a of {$ns}\NamedArgAction::run() expects int, string given.",
-                112,
+                124,
             ],
             [
                 "Parameter #2 \$a of {$ns}\AddAction::runIf() expects int, string given.",
-                118,
+                130,
             ],
             [
                 "{$ns}\AddAction::runIf() expects exactly 3 arguments, 0 given.",
-                127,
+                139,
             ],
             [
                 "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 0 given.",
-                128,
+                140,
             ],
             [
                 "{$ns}\NoParamsAction::runIf() expects exactly 1 argument, 2 given.",
-                142,
+                152,
             ],
         ]);
     }

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -78,6 +78,10 @@ final class RunParameterValidationRuleTest extends RuleTestCase
                 "Parameter #1 \$a of {$ns}\NamedArgAction::run() expects int, string given.",
                 91,
             ],
+            [
+                "Parameter #2 \$a of {$ns}\AddAction::runIf() expects int, string given.",
+                95,
+            ],
         ]);
     }
 }

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -79,24 +79,32 @@ final class RunParameterValidationRuleTest extends RuleTestCase
                 124,
             ],
             [
-                "Parameter #2 \$a of {$ns}\AddAction::runIf() expects int, string given.",
+                "Unknown parameter \$typo in call to {$ns}\NamedArgAction::run().",
+                129,
+            ],
+            [
+                "Unknown parameter \$typo in call to {$ns}\NamedArgAction::runIf().",
                 130,
             ],
             [
-                "{$ns}\AddAction::runIf() expects exactly 3 arguments, 0 given.",
+                "Parameter #2 \$a of {$ns}\AddAction::runIf() expects int, string given.",
                 139,
             ],
             [
+                "{$ns}\AddAction::runIf() expects exactly 3 arguments, 0 given.",
+                148,
+            ],
+            [
                 "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 0 given.",
-                140,
+                149,
             ],
             [
                 "{$ns}\NoParamsAction::runIf() expects exactly 1 argument, 2 given.",
-                152,
+                161,
             ],
             [
                 "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
-                189,
+                198,
             ],
         ]);
     }

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -31,43 +31,52 @@ final class RunParameterValidationRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/Fixtures/run-parameter-validation.php'], [
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 0 given.",
-                55,
+                54,
             ],
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 1 given.",
-                56,
+                55,
             ],
             [
                 "{$ns}\AddAction::runIf() expects exactly 3 arguments, 1 given.",
-                57,
+                56,
             ],
             [
                 "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 2 given.",
-                58,
+                57,
             ],
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 3 given.",
-                61,
+                60,
             ],
             [
                 "Parameter #1 \$a of {$ns}\AddAction::run() expects int, string given.",
-                64,
+                63,
             ],
             [
                 "Parameter #2 \$b of {$ns}\AddAction::run() expects int, string given.",
-                65,
+                64,
             ],
             [
                 "Parameter #1 \$a of {$ns}\OptionalAction::run() expects int, string given.",
-                66,
+                65,
             ],
             [
                 "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
-                69,
+                68,
             ],
             [
                 "Call to {$ns}\NoHandleAction::runIf() but class has no handle() method.",
-                70,
+                69,
+            ],
+            // Named argument type errors
+            [
+                "Parameter #3 \$c of {$ns}\NamedArgAction::run() expects float, string given.",
+                90,
+            ],
+            [
+                "Parameter #1 \$a of {$ns}\NamedArgAction::run() expects int, string given.",
+                91,
             ],
         ]);
     }

--- a/tests/PHPStan/RunParameterValidationRuleTest.php
+++ b/tests/PHPStan/RunParameterValidationRuleTest.php
@@ -31,68 +31,68 @@ final class RunParameterValidationRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/Fixtures/run-parameter-validation.php'], [
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 0 given.",
-                54,
+                77,
             ],
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 1 given.",
-                55,
+                78,
             ],
             [
                 "{$ns}\AddAction::runIf() expects exactly 3 arguments, 1 given.",
-                56,
+                79,
             ],
             [
                 "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 2 given.",
-                57,
+                80,
             ],
             [
                 "{$ns}\AddAction::run() expects exactly 2 arguments, 3 given.",
-                60,
+                85,
             ],
             [
                 "Parameter #1 \$a of {$ns}\AddAction::run() expects int, string given.",
-                63,
+                90,
             ],
             [
                 "Parameter #2 \$b of {$ns}\AddAction::run() expects int, string given.",
-                64,
+                91,
             ],
             [
                 "Parameter #1 \$a of {$ns}\OptionalAction::run() expects int, string given.",
-                65,
+                92,
             ],
             [
                 "Call to {$ns}\NoHandleAction::run() but class has no handle() method.",
-                68,
+                97,
             ],
             [
                 "Call to {$ns}\NoHandleAction::runIf() but class has no handle() method.",
-                69,
+                98,
             ],
             // Named argument type errors
             [
                 "Parameter #3 \$c of {$ns}\NamedArgAction::run() expects float, string given.",
-                90,
+                111,
             ],
             [
                 "Parameter #1 \$a of {$ns}\NamedArgAction::run() expects int, string given.",
-                91,
+                112,
             ],
             [
                 "Parameter #2 \$a of {$ns}\AddAction::runIf() expects int, string given.",
-                95,
+                118,
             ],
             [
                 "{$ns}\AddAction::runIf() expects exactly 3 arguments, 0 given.",
-                98,
+                127,
             ],
             [
                 "{$ns}\AddAction::runUnless() expects exactly 3 arguments, 0 given.",
-                99,
+                128,
             ],
             [
                 "{$ns}\NoParamsAction::runIf() expects exactly 1 argument, 2 given.",
-                122,
+                142,
             ],
         ]);
     }

--- a/tests/PHPStan/RunReturnTypeExtensionTest.php
+++ b/tests/PHPStan/RunReturnTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class RunReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/phpstan-test.neon'];
+    }
+
+    /** @return iterable<mixed> */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/Fixtures/run-return-types.php');
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testReturnTypes(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/PHPStan/RunThrowTypeExtensionTest.php
+++ b/tests/PHPStan/RunThrowTypeExtensionTest.php
@@ -41,6 +41,10 @@ final class RunThrowTypeExtensionTest extends RuleTestCase
                 "Function {$ns}\callThrowingRunUnless() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
                 63,
             ],
+            [
+                "Function {$ns}\callNonAction() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
+                79,
+            ],
         ]);
     }
 }

--- a/tests/PHPStan/RunThrowTypeExtensionTest.php
+++ b/tests/PHPStan/RunThrowTypeExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lorisleiva\Actions\Tests\PHPStan;
+
+use PHPStan\Rules\Exceptions\MissingCheckedExceptionInFunctionThrowsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<MissingCheckedExceptionInFunctionThrowsRule> */
+final class RunThrowTypeExtensionTest extends RuleTestCase
+{
+    private const NS = 'Lorisleiva\Actions\Tests\PHPStan\Fixtures';
+
+    /** @return string[] */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/phpstan-throw-test.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(MissingCheckedExceptionInFunctionThrowsRule::class);
+    }
+
+    public function testThrowTypePropagation(): void
+    {
+        $ns = self::NS;
+
+        $this->analyse([__DIR__ . '/Fixtures/run-throw-types.php'], [
+            [
+                "Function {$ns}\callThrowingWithoutDeclaring() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
+                38,
+            ],
+            [
+                "Function {$ns}\callThrowingRunIf() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
+                57,
+            ],
+            [
+                "Function {$ns}\callThrowingRunUnless() throws checked exception RuntimeException but it's missing from the PHPDoc @throws tag.",
+                63,
+            ],
+        ]);
+    }
+}

--- a/tests/PHPStan/phpstan-implicit-throw-test.neon
+++ b/tests/PHPStan/phpstan-implicit-throw-test.neon
@@ -1,0 +1,6 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    exceptions:
+        implicitThrows: true

--- a/tests/PHPStan/phpstan-test.neon
+++ b/tests/PHPStan/phpstan-test.neon
@@ -1,0 +1,2 @@
+includes:
+    - ../../extension.neon

--- a/tests/PHPStan/phpstan-throw-test.neon
+++ b/tests/PHPStan/phpstan-throw-test.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    exceptions:
+        implicitThrows: false
+        check:
+            missingCheckedExceptionInThrows: true
+        checkedExceptionClasses:
+            - RuntimeException


### PR DESCRIPTION
## Summary

Closes #260

`AsObject::run()` is defined as `(mixed...): mixed`, so PHPStan treats it as untyped: no return type inference, no parameter validation, and `@throws` annotations on `handle()` are invisible. This adds a PHPStan extension that makes `run()`, `runIf()`, and `runUnless()` transparent proxies to `handle()` for static analysis:

- **Return types**: `Action::run()` returns whatever `handle()` returns. `runIf()`/`runUnless()` return `handle() | Fluent`.
- **Parameter validation**: argument types, count, optionality, and variadics are checked against `handle()`'s signature.
- **`@throws` propagation**: `handle()`'s declared throw types carry through to callers of `run()`/`runIf()`/`runUnless()`.

This covers `run()`, `runIf()`, and `runUnless()` only. Several other methods (job and controller related) have the same `mixed ...$arguments` gap. I'd prefer to merge this as a first step and tackle those in a follow-up, but I'm also open to extending this PR if preferred.

### Setup

Similar to extensions shipped by [Larastan](https://github.com/larastan/larastan), [Carbon](https://github.com/CarbonPHP/carbon), and [Pest](https://github.com/pestphp/pest-plugin-type-coverage): if you use [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer), the extension is discovered automatically. Otherwise, include it manually in your `phpstan.neon`:

```neon
includes:
    - vendor/lorisleiva/laravel-actions/extension.neon
```