### PR TITLE
IDE helper as first party feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,16 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
-        "lorisleiva/lody": "^0.7"
+        "lorisleiva/lody": "^0.7",
+        "nikic/php-parser": "^4.0|^5.0",
+        "phpdocumentor/reflection": "^5.1|^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.0|^4.0",
-        "phpunit/phpunit": "^11.5|^12.0"
+        "phpunit/phpunit": "^11.5|^12.0",
+        "spatie/invade": "^1.1|^2.0",
+        "spatie/pest-plugin-snapshots": "^1.1|^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/ActionServiceProvider.php
+++ b/src/ActionServiceProvider.php
@@ -4,6 +4,7 @@ namespace Lorisleiva\Actions;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use Lorisleiva\Actions\Console\IdeHelperCommand;
 use Lorisleiva\Actions\Console\MakeActionCommand;
 use Lorisleiva\Actions\DesignPatterns\CommandDesignPattern;
 use Lorisleiva\Actions\DesignPatterns\ControllerDesignPattern;
@@ -41,6 +42,7 @@ class ActionServiceProvider extends ServiceProvider
             // Register the make:action generator command.
             $this->commands([
                 MakeActionCommand::class,
+                IdeHelperCommand::class,
             ]);
         }
     }

--- a/src/Console/IdeHelperCommand.php
+++ b/src/Console/IdeHelperCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lorisleiva\Actions\Console;
+
+use Illuminate\Console\Command;
+use Lorisleiva\Actions\IdeHelper\ActionInfoFactory;
+use Lorisleiva\Actions\IdeHelper\BuildIdeHelper;
+
+class IdeHelperCommand extends Command
+{
+    public $signature = 'ide-helper:actions';
+
+    public $description = 'Generate a new IDE Helper file for Laravel Actions.';
+
+    public function handle()
+    {
+        $actionsPath = app_path('Actions');
+        $outfile = base_path('_ide_helper_actions.php');
+
+        $actionInfos = ActionInfoFactory::create($actionsPath);
+        $result = BuildIdeHelper::create()->build($actionInfos);
+
+        file_put_contents($outfile, $result);
+
+        $this->comment('Action information was written to ' . basename($outfile));
+    }
+}

--- a/src/IdeHelper/ActionInfo.php
+++ b/src/IdeHelper/ActionInfo.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper;
+
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsCommand;
+use Lorisleiva\Actions\Concerns\AsController;
+use Lorisleiva\Actions\Concerns\AsFake;
+use Lorisleiva\Actions\Concerns\AsJob;
+use Lorisleiva\Actions\Concerns\AsListener;
+use Lorisleiva\Actions\Concerns\AsObject;
+use phpDocumentor\Reflection\Php\Class_;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsCommandGenerator;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsControllerGenerator;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsJobGenerator;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsListenerGenerator;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsObjectGenerator;
+
+final class ActionInfo
+{
+    public string $name;
+    public string $namespace;
+    public string $fqsen;
+    public bool $asObject;
+    public bool $asController;
+    public bool $asJob;
+    public bool $asListener;
+    public bool $asCommand;
+    public Class_ $classInfo;
+
+    const ALL_TRAITS = [
+        AsObject::class,
+        AsController::class,
+        AsJob::class,
+        AsListener::class,
+        AsCommand::class,
+        AsFake::class,
+    ];
+
+    public static function create(): ActionInfo
+    {
+        return new ActionInfo();
+    }
+
+    public function setName(string $name): ActionInfo
+    {
+        $this->fqsen = $name;
+        $this->name = class_basename($name);
+        $this->namespace = Str::of($name)->beforeLast('\\' . $this->name);
+
+        return $this;
+    }
+
+    public function setAsObject(bool $asObject): ActionInfo
+    {
+        $this->asObject = $asObject;
+        return $this;
+    }
+
+    public function setAsController(bool $asController): ActionInfo
+    {
+        $this->asController = $asController;
+        return $this;
+    }
+
+    public function setAsJob(bool $asJob): ActionInfo
+    {
+        $this->asJob = $asJob;
+        return $this;
+    }
+
+    public function setAsListener(bool $asListener): ActionInfo
+    {
+        $this->asListener = $asListener;
+        return $this;
+    }
+
+    public function setAsCommand(bool $asCommand): ActionInfo
+    {
+        $this->asCommand = $asCommand;
+        return $this;
+    }
+
+    public function setClassInfo(Class_ $classInfo): ActionInfo
+    {
+        $this->classInfo = $classInfo;
+        return $this;
+    }
+
+    /** @return \Lorisleiva\Actions\IdeHelper\Generator\DocBlock\DocBlockGeneratorInterface[] */
+    public function getGenerators(): array
+    {
+        return array_merge(
+            ($this->asCommand ? [AsCommandGenerator::class] : []),
+            ($this->asController ? [AsControllerGenerator::class] : []),
+            ($this->asJob ? [AsJobGenerator::class] : []),
+            ($this->asListener ? [AsListenerGenerator::class] : []),
+            ($this->asObject ? [AsObjectGenerator::class] : []),
+        );
+    }
+}

--- a/src/IdeHelper/ActionInfoFactory.php
+++ b/src/IdeHelper/ActionInfoFactory.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper;
+
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsCommand;
+use Lorisleiva\Actions\Concerns\AsController;
+use Lorisleiva\Actions\Concerns\AsJob;
+use Lorisleiva\Actions\Concerns\AsListener;
+use Lorisleiva\Actions\Concerns\AsObject;
+use phpDocumentor\Reflection\File\LocalFile;
+use phpDocumentor\Reflection\Php\File;
+use phpDocumentor\Reflection\Php\ProjectFactory;
+use ReflectionClass;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class ActionInfoFactory
+{
+    /** @return array<\Lorisleiva\Actions\IdeHelper\ActionInfo> */
+    public static function create(string $path): array
+    {
+        $factory = new self();
+        $classes = $factory->loadFromPath($path);
+        $classMap = $factory->loadPhpDocumentorReflectionClassMap($path);
+        $ais = [];
+        foreach ($classes as $class => $traits) {
+            $tc = collect($traits);
+            $ais[] = ActionInfo::create()
+                ->setName($class)
+                ->setAsObject($tc->contains(AsObject::class))
+                ->setAsCommand($tc->contains(AsCommand::class))
+                ->setAsController($tc->contains(AsController::class))
+                ->setAsJob($tc->contains(AsJob::class))
+                ->setAsListener($tc->contains(AsListener::class))
+                ->setClassInfo($classMap[$class]);
+        }
+        return $ais;
+    }
+
+    /** @return array<class-string,array<class-string>> */
+    protected function loadFromPath(string $path)
+    {
+        $finder = Finder::create()->files()->in($path)->name('*.php');
+        $result = [];
+
+        foreach ($finder as $file) {
+            $className = $this->getClassNameFromFile($file);
+
+            if ($className === null) {
+                continue;
+            }
+
+            if (! class_exists($className)) {
+                require_once $file->getRealPath();
+            }
+
+            if (! class_exists($className)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            $allTraits = $this->getAllTraits($reflection);
+            $matchingTraits = array_values(array_intersect($allTraits, ActionInfo::ALL_TRAITS));
+
+            if (! empty($matchingTraits)) {
+                $result[$className] = $matchingTraits;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function getClassNameFromFile(SplFileInfo $file): ?string
+    {
+        $content = file_get_contents($file->getRealPath());
+
+        if (
+            preg_match('/namespace\s+(.+?);/', $content, $nsMatch)
+            && preg_match('/class\s+(\w+)/', $content, $classMatch)
+        ) {
+            return $nsMatch[1] . '\\' . $classMatch[1];
+        }
+
+        return null;
+    }
+
+    /** @return array<class-string> */
+    protected function getAllTraits(ReflectionClass $class): array
+    {
+        $traits = [];
+
+        foreach ($class->getTraits() as $trait) {
+            $traits[] = $trait->getName();
+            $traits = array_merge($traits, $this->getTraitTraits($trait));
+        }
+
+        if ($parent = $class->getParentClass()) {
+            $traits = array_merge($traits, $this->getAllTraits($parent));
+        }
+
+        return array_unique($traits);
+    }
+
+    /** @return array<class-string> */
+    protected function getTraitTraits(ReflectionClass $trait): array
+    {
+        $traits = [];
+
+        foreach ($trait->getTraits() as $t) {
+            $traits[] = $t->getName();
+            $traits = array_merge($traits, $this->getTraitTraits($t));
+        }
+
+        return $traits;
+    }
+
+    /**
+     * @return array<\phpDocumentor\Reflection\Php\Class_>
+     * @throws \phpDocumentor\Reflection\Exception
+     */
+    protected function loadPhpDocumentorReflectionClassMap(string $path): array
+    {
+        $finder = Finder::create()->files()->in($path)->name('*.php');
+        $files = collect($finder)->map(fn(SplFileInfo $file) => new LocalFile($file->getRealPath()))->toArray();
+
+        $project = ProjectFactory::createInstance()->create('Laravel Actions IDE Helper', $files);
+        return collect($project->getFiles())
+            ->map(fn(File $f) => $f->getClasses())
+            ->collapse()
+            ->mapWithKeys(fn($item, string $key) => [Str::of($key)->ltrim("\\")->toString() => $item])
+            ->toArray();
+    }
+}

--- a/src/IdeHelper/BuildIdeHelper.php
+++ b/src/IdeHelper/BuildIdeHelper.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper;
+
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Serializer;
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\TypeResolver;
+use PhpParser\Builder\Trait_;
+use PhpParser\BuilderFactory;
+use PhpParser\Comment\Doc;
+use PhpParser\PrettyPrinter\Standard;
+
+class BuildIdeHelper
+{
+    public static function create(): BuildIdeHelper
+    {
+        return new BuildIdeHelper();
+    }
+
+    /** @param \Lorisleiva\Actions\IdeHelper\ActionInfo[] $actionInfos */
+    public function build(array $actionInfos): string
+    {
+        $groups = collect($actionInfos)->groupBy(function (ActionInfo $item) {
+            return $item->namespace;
+        })->toArray();
+
+        $nodes = [];
+        $factory = new BuilderFactory();
+        foreach ($groups as $namespace => $items) {
+            $ns = $factory->namespace($namespace);
+            foreach ($items as $item) {
+                $ns->addStmt($factory->class($item->classInfo->getName())->setDocComment(new Doc($this->generateDocBlocks($item))));
+            }
+            $nodes[] = $ns->getNode();
+        }
+        $nodes[] = $this->getTraitIdeHelpers($factory);
+        $printer = new Standard();
+        return $printer->prettyPrintFile($nodes);
+    }
+
+    protected function generateDocBlocks(ActionInfo $info): string
+    {
+        $tags = [];
+        foreach ($info->getGenerators() as $generator) {
+            $tags = array_merge($tags, $generator::create()->generate($info));
+        }
+        return $this->serializeDocBlocks(...$tags);
+    }
+
+    protected function serializeDocBlocks(Tag ...$tags): string
+    {
+        $db = new DocBlock('', null, $tags);
+        $serializer = new Serializer();
+        return $serializer->getDocComment($db);
+    }
+
+    protected function resolveType(string $type): Type
+    {
+        return (new TypeResolver())->resolve($type);
+    }
+
+    protected function resolveAsUnionType(string ...$types): Type
+    {
+        return (new TypeResolver())->resolve(implode('|', $types));
+    }
+
+    protected function getTraitIdeHelpers(BuilderFactory $factory): \PhpParser\Node
+    {
+        return $factory->namespace("Lorisleiva\Actions\Concerns")
+            ->addStmt(
+                (new Trait_("AsController"))->setDocComment(
+                    $this->serializeDocBlocks(
+                        new DocBlock\Tags\Method('asController', [], $this->resolveType('void'))
+                    )
+                )
+            )->addStmt(
+                (new Trait_("AsListener"))->setDocComment(
+                    $this->serializeDocBlocks(
+                        new DocBlock\Tags\Method('asListener', [], $this->resolveType('void'))
+                    )
+                )
+            )->addStmt(
+                (new Trait_("AsJob"))->setDocComment(
+                    $this->serializeDocBlocks(
+                        new DocBlock\Tags\Method('asJob', [], $this->resolveType('void'))
+                    )
+                )
+            )
+            ->addStmt(
+                (new Trait_("AsCommand"))->setDocComment(
+                    $this->serializeDocBlocks(
+                        new DocBlock\Tags\Method('asCommand', arguments: [
+                            ['name' => 'command', 'type' => $this->resolveType("\Illuminate\Console\Command")],
+                        ], returnType: $this->resolveType('void'))
+                    )
+                )
+            )
+            ->getNode();
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/AsCommandGenerator.php
+++ b/src/IdeHelper/Generator/DocBlock/AsCommandGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+
+class AsCommandGenerator extends DocBlockGeneratorBase implements DocBlockGeneratorInterface
+{
+    public function generate(ActionInfo $info): array
+    {
+        return [];
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/AsControllerGenerator.php
+++ b/src/IdeHelper/Generator/DocBlock/AsControllerGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+
+class AsControllerGenerator extends DocBlockGeneratorBase implements DocBlockGeneratorInterface
+{
+    public function generate(ActionInfo $info): array
+    {
+        return [];
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/AsJobGenerator.php
+++ b/src/IdeHelper/Generator/DocBlock/AsJobGenerator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Support\Fluent;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Types\Boolean;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\Custom\Method;
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+
+class AsJobGenerator extends DocBlockGeneratorBase implements DocBlockGeneratorInterface
+{
+    public function generate(ActionInfo $info): array
+    {
+        $method = $this->findMethod($info, 'asJob', 'handle');
+
+        if ($method == null) {
+            return [];
+        }
+
+        $args = $method->getArguments();
+
+        return [
+            new Method('makeJob', $args, $this->resolveAsUnionType(JobDecorator::class, UniqueJobDecorator::class), true),
+            new Method('makeUniqueJob', $args, $this->resolveType(UniqueJobDecorator::class), true),
+            new Method('dispatch', $args, $this->resolveType(PendingDispatch::class), true),
+            new Method('dispatchIf',
+                collect($args)->prepend(new Argument('boolean', new Boolean()))->toArray(),
+                $this->resolveAsUnionType(PendingDispatch::class, Fluent::class),
+                true),
+            new Method('dispatchUnless',
+                collect($args)->prepend(new Argument('boolean', new Boolean()))->toArray(),
+                $this->resolveAsUnionType(PendingDispatch::class, Fluent::class),
+                true),
+            new Method('dispatchSync', $args, null, true),
+            new Method('dispatchNow', $args, null, true),
+            new Method('dispatchAfterResponse', $args, null, true),
+        ];
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/AsListenerGenerator.php
+++ b/src/IdeHelper/Generator/DocBlock/AsListenerGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+
+class AsListenerGenerator extends DocBlockGeneratorBase implements DocBlockGeneratorInterface
+{
+    public function generate(ActionInfo $info): array
+    {
+        return [];
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/AsObjectGenerator.php
+++ b/src/IdeHelper/Generator/DocBlock/AsObjectGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\Custom\Method;
+
+class AsObjectGenerator extends DocBlockGeneratorBase implements DocBlockGeneratorInterface
+{
+    public function generate(ActionInfo $info): array
+    {
+        $method = $this->findMethod($info, 'handle');
+        return $method == null ? [] : [new Method('run', $method->getArguments(), $method->getReturnType(), true)];
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/Custom/Method.php
+++ b/src/IdeHelper/Generator/DocBlock/Custom/Method.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock\Custom;
+
+use phpDocumentor\Reflection\DocBlock\Description;
+use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
+use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Type;
+
+class Method extends BaseTag
+{
+    protected string $name = 'method';
+
+    /** @param array<\phpDocumentor\Reflection\Php\Argument> $arguments */
+    public function __construct(
+        protected string $methodName,
+        protected array $arguments = [],
+        protected ?Type $returnType = null,
+        protected bool $static = false,
+        protected ?Description $description = null
+    ) {
+    }
+
+    public static function create(string $body)
+    {
+        // TODO: Implement create() method.
+    }
+
+    public function __toString(): string
+    {
+        $s = '';
+        if ($this->static) {
+            $s .= 'static ';
+        }
+
+        if ($this->returnType) {
+            $s .= (string) $this->returnType . ' ';
+        }
+
+        $s .= $this->methodName . '(';
+        $s .= collect($this->arguments)->map(fn(Argument $arg) => $this->stringifyArgument($arg))->implode(', ');
+        $s .= ')';
+
+        return $s;
+    }
+
+    protected function stringifyArgument(Argument $argument): string
+    {
+        $s = "";
+        $type = $argument->getType();
+        if ($type) {
+            $s .= (string) $type . " ";
+        }
+
+        if ($argument->isVariadic()) {
+            $s .= "...";
+        }
+
+        if ($argument->isByReference()) {
+            $s .= "&";
+        }
+
+        $s .= '$' . $argument->getName();
+
+        $default = $argument->getDefault();
+        if ($default) {
+            $s .= ' = ' . $default;
+        }
+
+        return $s;
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/DocBlockGeneratorBase.php
+++ b/src/IdeHelper/Generator/DocBlock/DocBlockGeneratorBase.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\TypeResolver;
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+
+class DocBlockGeneratorBase implements DocBlockGeneratorInterface
+{
+    public static function create(): static
+    {
+        return new static();
+    }
+
+    protected function resolveType(string $type): Type
+    {
+        return (new TypeResolver())->resolve($type);
+    }
+
+    protected function resolveAsUnionType(string ...$types): Type
+    {
+        return (new TypeResolver())->resolve(implode('|', $types));
+    }
+
+    public function generate(ActionInfo $info): array
+    {
+        return [];
+    }
+
+    protected function convertArguments(array $arguments): array
+    {
+        return collect($arguments)
+            ->transform(fn(Argument $arg) => ['name' => $arg->getName(), 'type' => $arg->getType()])
+            ->toArray();
+    }
+
+    protected function findMethod(ActionInfo $info, string ...$methods): ?\phpDocumentor\Reflection\Php\Method
+    {
+        foreach ($methods as $method) {
+            $m = collect($info->classInfo->getMethods())
+                ->filter(fn(\phpDocumentor\Reflection\Php\Method $m) => $m->getName() == $method)
+                ->first();
+            if (!empty($m)) {
+                return $m;
+            }
+        }
+        return null;
+    }
+}

--- a/src/IdeHelper/Generator/DocBlock/DocBlockGeneratorInterface.php
+++ b/src/IdeHelper/Generator/DocBlock/DocBlockGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lorisleiva\Actions\IdeHelper\Generator\DocBlock;
+
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+
+interface DocBlockGeneratorInterface
+{
+    public static function create(): self;
+
+    /** @return \phpDocumentor\Reflection\DocBlock\Tag[] */
+    public function generate(ActionInfo $info): array;
+}

--- a/tests/IdeHelper/ActionInfoFactoryTest.php
+++ b/tests/IdeHelper/ActionInfoFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Lorisleiva\Actions\Concerns\AsJob;
+use Lorisleiva\Actions\Concerns\AsObject;
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+use Lorisleiva\Actions\IdeHelper\ActionInfoFactory;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\BaseAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\NewAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\NotAnAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\TestAction;
+use phpDocumentor\Reflection\Php\Class_;
+
+it('creates a correct trait lookup', function () {
+    $result = invade(new ActionInfoFactory())->loadFromPath(__DIR__ . '/stubs');
+
+    expect($result)->toBeArray();
+    expect($result[BaseAction::class])->toEqual([AsObject::class]);
+    expect($result[NewAction::class])->toContain(AsObject::class, AsJob::class);
+    expect($result[TestAction::class])->toContain(...ActionInfo::ALL_TRAITS);
+
+    expect(collect($result)->keys()->toArray())->not()->toContain(NotAnAction::class);
+});
+
+it('creates correct ActionInfos', function () {
+    $ai = getIdeHelperActionInfo(BaseAction::class);
+
+    expect($ai->asObject)->toBeTrue();
+    expect($ai->asCommand)->toBeFalse();
+
+    expect($ai->classInfo instanceof Class_)->toBeTrue();
+    expect($ai->classInfo)->not()->toBeNull();
+});
+
+it('parses the classes correctly', function () {
+    $result = invade(new ActionInfoFactory())->loadPhpDocumentorReflectionClassMap(__DIR__ . '/stubs');
+
+    $keys = collect($result)->keys()->toArray();
+    expect($keys)->toContain(NotAnAction::class, BaseAction::class, TestAction::class);
+});

--- a/tests/IdeHelper/Generators/BaseGeneratorTest.php
+++ b/tests/IdeHelper/Generators/BaseGeneratorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\DocBlockGeneratorBase;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\EmptyAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs\WithDecoratorAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs\WithoutDecoratorAction;
+
+it('cannot find a method that is not there', function () {
+    $ai = getIdeHelperActionInfo(EmptyAction::class);
+    $method = invade(new DocBlockGeneratorBase())->findMethod($ai, 'handle');
+    expect($method)->toBeNull();
+});
+
+it('can find a method in the correct precedence', function () {
+    $ai = getIdeHelperActionInfo(WithDecoratorAction::class);
+    /** @var \phpDocumentor\Reflection\Php\Method $method */
+    $method = invade(new DocBlockGeneratorBase())->findMethod($ai, 'asJob', 'handle');
+    expect($method->getName())->toBe('asJob');
+});
+
+it('can find a method in the correct precedence even when one is not present', function () {
+    $ai = getIdeHelperActionInfo(WithoutDecoratorAction::class);
+    /** @var \phpDocumentor\Reflection\Php\Method $method */
+    $method = invade(new DocBlockGeneratorBase())->findMethod($ai, 'asJob', 'handle');
+    expect($method->getName())->toBe('handle');
+});

--- a/tests/IdeHelper/Generators/JobGeneratorTest.php
+++ b/tests/IdeHelper/Generators/JobGeneratorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsJobGenerator;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs\WithDecoratorAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs\WithoutDecoratorAction;
+
+it('runs without an error', function (string $class, array $expectations) {
+    $ai = getIdeHelperActionInfo($class);
+
+    $docblock = collect((new AsJobGenerator())->generate($ai));
+
+    expect($docblock->count())->toEqual(8);
+
+    $all = $docblock->map(fn($item) => $item->render())->implode(PHP_EOL);
+    foreach ($expectations as $expectation) {
+        expect($all)->toContain($expectation);
+    }
+})->with([
+    'with decorator' => [
+        WithDecoratorAction::class, [
+            '@method static \\' . JobDecorator::class . '|\\' . UniqueJobDecorator::class . ' makeJob(int $i)',
+        ],
+    ],
+    'without decorator' => [
+        WithoutDecoratorAction::class, [
+            '@method static \\' . JobDecorator::class . '|\\' . UniqueJobDecorator::class . ' makeJob()',
+        ],
+    ],
+]);

--- a/tests/IdeHelper/Generators/ObjectGeneratorTest.php
+++ b/tests/IdeHelper/Generators/ObjectGeneratorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\AsObjectGenerator;
+use Lorisleiva\Actions\IdeHelper\Generator\DocBlock\Custom\Method;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\BaseAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\DefaultParameterValuesAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\UnionTypeAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\VoidAction;
+use Lorisleiva\Actions\Tests\IdeHelper\stubs\VoidActionWithNoReturnType;
+
+it('can render the run method', function (string $class, string $docblockExpectation) {
+    $ai = getIdeHelperActionInfo($class);
+
+    /** @var \phpDocumentor\Reflection\DocBlock\Tag $docblock */
+    $docblock = collect((new AsObjectGenerator())->generate($ai))->first();
+    expect($docblock)->toBeInstanceOf(Method::class);
+
+    expect($docblock->render())->toEqual($docblockExpectation);
+})->with([
+    "BaseAction" => [BaseAction::class, '@method static string run()'],
+    "UnionTypeAction" => [UnionTypeAction::class, '@method static int|string run(string $string, float|int $number)'],
+    "VoidAction" => [VoidAction::class, '@method static void run(int $i)'],
+    "VoidActionWithNoReturnType" => [VoidActionWithNoReturnType::class, '@method static mixed run()'],
+]);
+
+it('can render the run method with default parameter values', function () {
+    $ai = getIdeHelperActionInfo(DefaultParameterValuesAction::class);
+
+    /** @var \phpDocumentor\Reflection\DocBlock\Tag $docblock */
+    $docblock = collect((new AsObjectGenerator())->generate($ai))->first();
+    expect($docblock)->toBeInstanceOf(Method::class);
+
+    $docblockExpectation = '@method static int run(string $s, bool $var = false)';
+    expect($docblock->render())->toEqual($docblockExpectation);
+});

--- a/tests/IdeHelper/IdeHelperOutputTest.php
+++ b/tests/IdeHelper/IdeHelperOutputTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Lorisleiva\Actions\IdeHelper\ActionInfoFactory;
+use Lorisleiva\Actions\IdeHelper\BuildIdeHelper;
+
+use function Spatie\Snapshots\assertMatchesSnapshot;
+
+it('can render the output so it matches the snapshot', function () {
+    $actionInfos = ActionInfoFactory::create(__DIR__ . '/stubs');
+
+    $result = BuildIdeHelper::create()->build($actionInfos);
+
+    assertMatchesSnapshot($result);
+});
+
+it('can render intersection types', function () {
+    $actionInfos = ActionInfoFactory::create(__DIR__ . '/stubs/IntersectionTypes');
+
+    $result = BuildIdeHelper::create()->build($actionInfos);
+
+    assertMatchesSnapshot($result);
+});

--- a/tests/IdeHelper/stubs/BaseAction.php
+++ b/tests/IdeHelper/stubs/BaseAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsObject;
+
+class BaseAction
+{
+    use AsObject;
+
+    public function handle(): string
+    {
+        return "";
+    }
+}

--- a/tests/IdeHelper/stubs/DefaultParameterValuesAction.php
+++ b/tests/IdeHelper/stubs/DefaultParameterValuesAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DefaultParameterValuesAction
+{
+    use AsAction;
+
+    public function handle(string $s, bool $var = false): int
+    {
+        return 0;
+    }
+}

--- a/tests/IdeHelper/stubs/EmptyAction.php
+++ b/tests/IdeHelper/stubs/EmptyAction.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class EmptyAction
+{
+    use AsAction;
+}

--- a/tests/IdeHelper/stubs/IntersectionTypes/IntersectionAction.php
+++ b/tests/IdeHelper/stubs/IntersectionTypes/IntersectionAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\IntersectionTypes;
+
+use Lorisleiva\Actions\Concerns\AsObject;
+use PhpParser\Node\Expr\Array_;
+
+class IntersectionAction
+{
+    use AsObject;
+
+    public function handle(\stdClass&Array_ $permissionable): ?\stdClass
+    {
+        return null;
+    }
+}

--- a/tests/IdeHelper/stubs/Jobs/WithDecoratorAction.php
+++ b/tests/IdeHelper/stubs/Jobs/WithDecoratorAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs;
+
+use Lorisleiva\Actions\Concerns\AsJob;
+
+class WithDecoratorAction
+{
+    use AsJob;
+
+    public function handle()
+    {
+    }
+
+    public function asJob(int $i): void
+    {
+    }
+}

--- a/tests/IdeHelper/stubs/Jobs/WithoutDecoratorAction.php
+++ b/tests/IdeHelper/stubs/Jobs/WithoutDecoratorAction.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs;
+
+use Lorisleiva\Actions\Concerns\AsJob;
+
+class WithoutDecoratorAction
+{
+    use AsJob;
+
+    public function handle()
+    {
+    }
+}

--- a/tests/IdeHelper/stubs/NewAction.php
+++ b/tests/IdeHelper/stubs/NewAction.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsJob;
+
+class NewAction extends BaseAction
+{
+    use AsJob;
+
+    public function test()
+    {
+    }
+}

--- a/tests/IdeHelper/stubs/NotAnAction.php
+++ b/tests/IdeHelper/stubs/NotAnAction.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+class NotAnAction
+{
+}

--- a/tests/IdeHelper/stubs/Object/ObjectAction.php
+++ b/tests/IdeHelper/stubs/Object/ObjectAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\Object;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ObjectAction
+{
+    use AsAction;
+
+    public function handle(string $string, float|int $number): int|string
+    {
+        return 0;
+    }
+}

--- a/tests/IdeHelper/stubs/TestAction.php
+++ b/tests/IdeHelper/stubs/TestAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class TestAction
+{
+    use AsAction;
+
+    /**
+     * @returns int
+     */
+    public function handle(...$someArguments)
+    {
+        // Your action logic here...
+    }
+}

--- a/tests/IdeHelper/stubs/UnionTypeAction.php
+++ b/tests/IdeHelper/stubs/UnionTypeAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UnionTypeAction
+{
+    use AsAction;
+
+    public function handle(string $string, float|int $number): int|string
+    {
+        return 0;
+    }
+}

--- a/tests/IdeHelper/stubs/VoidAction.php
+++ b/tests/IdeHelper/stubs/VoidAction.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class VoidAction
+{
+    use AsAction;
+
+    public function handle(int $i): void
+    {
+    }
+}

--- a/tests/IdeHelper/stubs/VoidActionWithNoReturnType.php
+++ b/tests/IdeHelper/stubs/VoidActionWithNoReturnType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class VoidActionWithNoReturnType
+{
+    use AsAction;
+
+    public function handle()
+    {
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,8 @@
 use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use Lorisleiva\Actions\IdeHelper\ActionInfo;
+use Lorisleiva\Actions\IdeHelper\ActionInfoFactory;
 use Lorisleiva\Actions\Tests\Stubs\CustomJobDecorator;
 use Lorisleiva\Actions\Tests\Stubs\CustomUniqueJobDecorator;
 use Lorisleiva\Actions\Tests\TestCase;
@@ -23,6 +25,14 @@ dataset('custom job decorators', [
         return CustomJobDecorator::class;
     },
 ]);
+
+/** @param class-string $class */
+function getIdeHelperActionInfo(string $class): ActionInfo
+{
+    $actionInfos = collect(ActionInfoFactory::create(__DIR__ . '/IdeHelper/stubs'));
+
+    return $actionInfos->filter(fn(ActionInfo $ai) => $ai->fqsen == $class)->firstOrFail();
+}
 
 dataset('custom unique job decorators', [
     'default job decorator class' => [UniqueJobDecorator::class],

--- a/tests/__snapshots__/IdeHelperOutputTest__it_can_render_intersection_types__2.txt
+++ b/tests/__snapshots__/IdeHelperOutputTest__it_can_render_intersection_types__2.txt
@@ -1,0 +1,36 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\IntersectionTypes;
+
+/**
+ * @method static ?\stdClass run(\stdClass&\PhpParser\Node\Expr\Array_ $permissionable)
+ */
+class IntersectionAction
+{
+}
+namespace Lorisleiva\Actions\Concerns;
+
+/**
+ * @method void asController()
+ */
+trait AsController
+{
+}
+/**
+ * @method void asListener()
+ */
+trait AsListener
+{
+}
+/**
+ * @method void asJob()
+ */
+trait AsJob
+{
+}
+/**
+ * @method void asCommand(\Illuminate\Console\Command $command)
+ */
+trait AsCommand
+{
+}

--- a/tests/__snapshots__/IdeHelperOutputTest__it_can_render_the_output_so_it_matches_the_snapshot__2.txt
+++ b/tests/__snapshots__/IdeHelperOutputTest__it_can_render_the_output_so_it_matches_the_snapshot__2.txt
@@ -1,0 +1,168 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs;
+
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob(string $string, float|int $number)
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob(string $string, float|int $number)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch(string $string, float|int $number)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean, string $string, float|int $number)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean, string $string, float|int $number)
+ * @method static dispatchSync(string $string, float|int $number)
+ * @method static dispatchNow(string $string, float|int $number)
+ * @method static dispatchAfterResponse(string $string, float|int $number)
+ * @method static int|string run(string $string, float|int $number)
+ */
+class UnionTypeAction
+{
+}
+/**
+ */
+class EmptyAction
+{
+}
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob()
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob()
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch()
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean)
+ * @method static dispatchSync()
+ * @method static dispatchNow()
+ * @method static dispatchAfterResponse()
+ * @method static mixed run()
+ */
+class VoidActionWithNoReturnType
+{
+}
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob(mixed ...$someArguments)
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob(mixed ...$someArguments)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch(mixed ...$someArguments)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean, mixed ...$someArguments)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean, mixed ...$someArguments)
+ * @method static dispatchSync(mixed ...$someArguments)
+ * @method static dispatchNow(mixed ...$someArguments)
+ * @method static dispatchAfterResponse(mixed ...$someArguments)
+ * @method static mixed run(mixed ...$someArguments)
+ */
+class TestAction
+{
+}
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob(string $s, bool $var = false)
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob(string $s, bool $var = false)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch(string $s, bool $var = false)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean, string $s, bool $var = false)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean, string $s, bool $var = false)
+ * @method static dispatchSync(string $s, bool $var = false)
+ * @method static dispatchNow(string $s, bool $var = false)
+ * @method static dispatchAfterResponse(string $s, bool $var = false)
+ * @method static int run(string $s, bool $var = false)
+ */
+class DefaultParameterValuesAction
+{
+}
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob(int $i)
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob(int $i)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch(int $i)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean, int $i)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean, int $i)
+ * @method static dispatchSync(int $i)
+ * @method static dispatchNow(int $i)
+ * @method static dispatchAfterResponse(int $i)
+ * @method static void run(int $i)
+ */
+class VoidAction
+{
+}
+/**
+ * @method static string run()
+ */
+class BaseAction
+{
+}
+/**
+ */
+class NewAction
+{
+}
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\Object;
+
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob(string $string, float|int $number)
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob(string $string, float|int $number)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch(string $string, float|int $number)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean, string $string, float|int $number)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean, string $string, float|int $number)
+ * @method static dispatchSync(string $string, float|int $number)
+ * @method static dispatchNow(string $string, float|int $number)
+ * @method static dispatchAfterResponse(string $string, float|int $number)
+ * @method static int|string run(string $string, float|int $number)
+ */
+class ObjectAction
+{
+}
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\Jobs;
+
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob(int $i)
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob(int $i)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch(int $i)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean, int $i)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean, int $i)
+ * @method static dispatchSync(int $i)
+ * @method static dispatchNow(int $i)
+ * @method static dispatchAfterResponse(int $i)
+ */
+class WithDecoratorAction
+{
+}
+/**
+ * @method static \Lorisleiva\Actions\Decorators\JobDecorator|\Lorisleiva\Actions\Decorators\UniqueJobDecorator makeJob()
+ * @method static \Lorisleiva\Actions\Decorators\UniqueJobDecorator makeUniqueJob()
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch dispatch()
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchIf(bool $boolean)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent dispatchUnless(bool $boolean)
+ * @method static dispatchSync()
+ * @method static dispatchNow()
+ * @method static dispatchAfterResponse()
+ */
+class WithoutDecoratorAction
+{
+}
+namespace Lorisleiva\Actions\Tests\IdeHelper\stubs\IntersectionTypes;
+
+/**
+ * @method static ?\stdClass run(\stdClass&\PhpParser\Node\Expr\Array_ $permissionable)
+ */
+class IntersectionAction
+{
+}
+namespace Lorisleiva\Actions\Concerns;
+
+/**
+ * @method void asController()
+ */
+trait AsController
+{
+}
+/**
+ * @method void asListener()
+ */
+trait AsListener
+{
+}
+/**
+ * @method void asJob()
+ */
+trait AsJob
+{
+}
+/**
+ * @method void asCommand(\Illuminate\Console\Command $command)
+ */
+trait AsCommand
+{
+}


### PR DESCRIPTION
I would like to make this a first party feature. [I will maintain it.](https://github.com/lorisleiva/laravel-actions/issues/117#issuecomment-1890907488) It currently is just a straight transfer of [the original repo](https://github.com/Wulfheart/laravel-actions-ide-helper/) with updated namespace. 

I [periodically submit PRs](https://github.com/Wulfheart/laravel-actions-ide-helper/pulls?q=is%3Apr+author%3Aadrum+) to the original repo, but it would be nice to consolidate these two.
