### PR TITLE
Add debounced job support to the AsJob trait

### DIFF
--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Router;
 use Lorisleiva\Actions\Concerns\AsCommand;
 use Lorisleiva\Actions\Concerns\AsController;
 use Lorisleiva\Actions\Concerns\AsFake;
+use Lorisleiva\Actions\Decorators\DebounceJobDecorator;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
 use Lorisleiva\Actions\DesignPatterns\DesignPattern;
@@ -21,6 +22,9 @@ class ActionManager
 
     /** @var class-string<JobDecorator&ShouldBeUnique> */
     public static string $uniqueJobDecorator = UniqueJobDecorator::class;
+
+    /** @var class-string<DebounceJobDecorator> */
+    public static string $debounceJobDecorator = DebounceJobDecorator::class;
 
     /** @var DesignPattern[] */
     protected array $designPatterns = [];
@@ -49,6 +53,14 @@ class ActionManager
     public static function useUniqueJobDecorator(string $uniqueJobDecoratorClass): void
     {
         static::$uniqueJobDecorator = $uniqueJobDecoratorClass;
+    }
+
+    /**
+     * @param class-string<DebounceJobDecorator> $debounceJobDecoratorClass
+     */
+    public static function useDebounceJobDecorator(string $debounceJobDecoratorClass): void
+    {
+        static::$debounceJobDecorator = $debounceJobDecoratorClass;
     }
 
     public function setBacktraceLimit(int $backtraceLimit): ActionManager

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -6,13 +6,18 @@ use Closure;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Fluent;
 use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\ActionPendingChain;
+use Lorisleiva\Actions\DebouncePendingDispatch;
+use Lorisleiva\Actions\Decorators\DebounceJobDecorator;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Decorators\UniqueJobDecorator;
+use LogicException;
 use PHPUnit\Framework\Assert as PHPUnit;
+use ReflectionClass;
 use Throwable;
 
 /**
@@ -21,7 +26,7 @@ use Throwable;
  * @property-read int $jobTries
  * @property-read int $jobMaxExceptions
  * @property-read int $jobTimeout
- * @method void configureJob(JobDecorator|UniqueJobDecorator $job)
+ * @method void configureJob(JobDecorator|UniqueJobDecorator|DebounceJobDecorator $job)
  *
  * @property-read int|array $jobBackoff
  * @method int|array getJobBackoff()
@@ -48,13 +53,26 @@ use Throwable;
  * @property-read bool $jobDeleteWhenMissingModels
  * @method bool getJobDeleteWhenMissingModels()
  *
+ * @property-read string $jobDebounceId
+ * @method string getJobDebounceId()
+ *
+ * @method \Illuminate\Contracts\Cache\Repository getJobDebounceVia()
+ *
  */
 trait AsJob
 {
     public static function makeJob(mixed ...$arguments): JobDecorator
     {
+        if (static::jobShouldBeUnique() && static::jobShouldBeDebounced()) {
+            throw new LogicException('A debounced job cannot also implement ShouldBeUnique.');
+        }
+
         if (static::jobShouldBeUnique()) {
             return static::makeUniqueJob(...$arguments);
+        }
+
+        if (static::jobShouldBeDebounced()) {
+            return static::makeDebounceJob(...$arguments);
         }
 
         return new ActionManager::$jobDecorator(static::class, ...$arguments);
@@ -65,14 +83,29 @@ trait AsJob
         return new ActionManager::$uniqueJobDecorator(static::class, ...$arguments);
     }
 
+    public static function makeDebounceJob(mixed ...$arguments): DebounceJobDecorator
+    {
+        return new ActionManager::$debounceJobDecorator(static::class, ...$arguments);
+    }
+
     protected static function jobShouldBeUnique(): bool
     {
         return is_subclass_of(static::class, ShouldBeUnique::class);
     }
 
+    protected static function jobShouldBeDebounced(): bool
+    {
+        return class_exists(DebounceFor::class)
+            && (new ReflectionClass(static::class))->getAttributes(DebounceFor::class) !== [];
+    }
+
     public static function dispatch(mixed ...$arguments): PendingDispatch
     {
-        return new PendingDispatch(static::makeJob(...$arguments));
+        $job = static::makeJob(...$arguments);
+
+        return static::jobShouldBeDebounced()
+            ? new DebouncePendingDispatch($job)
+            : new PendingDispatch($job);
     }
 
     public static function dispatchIf(bool $boolean, mixed ...$arguments): PendingDispatch|Fluent
@@ -112,9 +145,11 @@ trait AsJob
             $times = null;
         }
 
-        $decoratorClass = static::jobShouldBeUnique()
-            ? ActionManager::$uniqueJobDecorator
-            : ActionManager::$jobDecorator;
+        $decoratorClass = match (true) {
+            static::jobShouldBeUnique() => ActionManager::$uniqueJobDecorator,
+            static::jobShouldBeDebounced() => ActionManager::$debounceJobDecorator,
+            default => ActionManager::$jobDecorator,
+        };
 
         $count = Queue::pushed($decoratorClass, function (JobDecorator $job, $queue) use ($callback) {
             if (! $job->decorates(static::class)) {

--- a/src/DebouncePendingDispatch.php
+++ b/src/DebouncePendingDispatch.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Lorisleiva\Actions;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Foundation\Bus\PendingDispatch;
+
+class DebouncePendingDispatch extends PendingDispatch
+{
+    /**
+     * Acquire a debounce lock for the job and set its delay.
+     *
+     * Overrides Laravel's implementation so that both the debounce duration and
+     * the (otherwise dropped) maxWait value forwarded by the DebounceJobDecorator
+     * are passed to the lock. The unique-vs-debounced conflict is enforced earlier
+     * in AsJob::makeJob(), which covers every dispatch path.
+     */
+    protected function acquireDebounceLock()
+    {
+        $job = $this->job;
+
+        $debounceFor = $job->debounceFor ?? null;
+
+        if ($debounceFor === null) {
+            return;
+        }
+
+        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
+
+        $result = $lock->acquire($job, $debounceFor, $job->maxWait ?? null);
+
+        $job->debounceOwner = $result['owner'];
+
+        if (is_null($job->delay)) {
+            $job->delay = $result['maxWaitExceeded'] ? 0 : $debounceFor;
+        }
+    }
+}

--- a/src/Decorators/DebounceJobDecorator.php
+++ b/src/Decorators/DebounceJobDecorator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lorisleiva\Actions\Decorators;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Attributes\DebounceFor;
+use ReflectionClass;
+
+class DebounceJobDecorator extends JobDecorator
+{
+    public ?int $debounceFor = null;
+    public ?int $maxWait = null;
+
+    protected function constructed(): void
+    {
+        $attributes = (new ReflectionClass($this->action))->getAttributes(DebounceFor::class);
+
+        if (! empty($attributes)) {
+            $instance = $attributes[0]->newInstance();
+            $this->debounceFor = $instance->debounceFor;
+            $this->maxWait = $instance->maxWait;
+        }
+
+        parent::constructed();
+    }
+
+    public function debounceId(): string
+    {
+        return (string) $this->fromActionMethodOrProperty(
+            'getJobDebounceId',
+            'jobDebounceId',
+            '',
+            $this->parameters
+        );
+    }
+
+    public function debounceVia()
+    {
+        return $this->fromActionMethod('getJobDebounceVia', $this->parameters, function () {
+            return Container::getInstance()->make(Cache::class);
+        });
+    }
+}

--- a/tests/AsDebounceJobTest.php
+++ b/tests/AsDebounceJobTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+use Lorisleiva\Actions\Concerns\AsJob;
+use Lorisleiva\Actions\Decorators\DebounceJobDecorator;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+use LogicException;
+
+#[DebounceFor(30)]
+class AsDebounceJobTest
+{
+    use AsJob;
+
+    public static ?Repository $cache;
+
+    public function handle(int $id = 1): void
+    {
+        //
+    }
+
+    public function getJobDebounceId(int $id = 1): int
+    {
+        return $id;
+    }
+
+    public function getJobDebounceVia(): Repository
+    {
+        return static::$cache = Cache::driver('array');
+    }
+}
+
+#[DebounceFor(30, maxWait: 60)]
+class AsDebounceJobWithMaxWaitTest
+{
+    use AsJob;
+
+    public function handle(): void
+    {
+        //
+    }
+
+    public function getJobDebounceVia(): Repository
+    {
+        return Cache::driver('array');
+    }
+}
+
+#[DebounceFor(30)]
+class AsDebounceJobThatIsAlsoUniqueTest implements ShouldBeUnique
+{
+    use AsJob;
+
+    public function handle(): void
+    {
+        //
+    }
+}
+
+beforeEach(function () {
+    // Debounced jobs are only available on Laravel 13.6+.
+    if (! class_exists(DebounceFor::class)) {
+        test()->markTestSkipped('Debounced jobs require Laravel 13.6+.');
+    }
+
+    // Given we mock the queue driver.
+    Queue::fake();
+
+    // And reset the cache.
+    AsDebounceJobTest::$cache = null;
+});
+
+it('makes debounce jobs by default when the action has the DebounceFor attribute', function () {
+    // When we make a job from the action.
+    $job = AsDebounceJobTest::makeJob();
+
+    // Then it returns a DebounceJobDecorator.
+    expect($job)->toBeInstanceOf(DebounceJobDecorator::class);
+});
+
+it('forwards the debounceFor value from the action attribute to the decorator', function () {
+    // When we make a job from the action.
+    $job = AsDebounceJobTest::makeJob();
+
+    // Then the debounceFor property is set from the action's DebounceFor attribute.
+    expect($job->debounceFor)->toBe(30);
+});
+
+it('forwards the maxWait value from the action attribute to the decorator', function () {
+    // When we make a job from an action whose attribute defines maxWait.
+    $job = AsDebounceJobWithMaxWaitTest::makeJob();
+
+    // Then both debounceFor and maxWait are forwarded.
+    expect($job->debounceFor)->toBe(30);
+    expect($job->maxWait)->toBe(60);
+});
+
+it('forwards the debounce id from the action', function () {
+    // When we make a job from the action with a specific id.
+    $job = AsDebounceJobTest::makeJob(42);
+
+    // Then the debounceId reflects the action parameter.
+    expect($job->debounceId())->toContain('42');
+});
+
+it('uses the cache driver provided in getJobDebounceVia', function () {
+    // When we dispatch a debounced job.
+    AsDebounceJobTest::dispatch();
+
+    // Then the action's debounce cache driver was used.
+    expect(AsDebounceJobTest::$cache)->not->toBeNull();
+});
+
+it('can be tested using the assertPushed helper method', function () {
+    // When we dispatch a debounced job.
+    AsDebounceJobTest::dispatch(10);
+
+    // Then we can assert it has been pushed using helper methods.
+    AsDebounceJobTest::assertPushed();
+});
+
+it('cannot be both unique and debounced', function () {
+    // When we try to dispatch an action that is both unique and debounced
+    // Then a LogicException is thrown, matching Laravel's own behaviour.
+    expect(fn () => AsDebounceJobThatIsAlsoUniqueTest::dispatch())
+        ->toThrow(LogicException::class, 'A debounced job cannot also implement ShouldBeUnique.');
+});
+
+it('dispatches a debounced job as a DebounceJobDecorator', function () {
+    // When we dispatch a debounced job.
+    AsDebounceJobTest::dispatch(42);
+
+    // Then it is pushed to the queue as a DebounceJobDecorator.
+    Queue::assertPushed(DebounceJobDecorator::class, function (JobDecorator $job) {
+        return $job->debounceFor === 30;
+    });
+});

--- a/tests/AsDebounceJobUsingPropertiesTest.php
+++ b/tests/AsDebounceJobUsingPropertiesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Support\Facades\Queue;
+use Lorisleiva\Actions\Concerns\AsJob;
+use Lorisleiva\Actions\Decorators\DebounceJobDecorator;
+
+#[DebounceFor(30)]
+class AsDebounceJobUsingPropertiesTest
+{
+    use AsJob;
+
+    public string $jobDebounceId = 'my_debounce_id';
+
+    public function handle(): void
+    {
+        //
+    }
+}
+
+beforeEach(function () {
+    // Debounced jobs are only available on Laravel 13.6+.
+    if (! class_exists(DebounceFor::class)) {
+        test()->markTestSkipped('Debounced jobs require Laravel 13.6+.');
+    }
+
+    Queue::fake();
+});
+
+it('makes debounce jobs by default when using properties', function () {
+    // When we make a job from the action.
+    $job = AsDebounceJobUsingPropertiesTest::makeJob();
+
+    // Then it returns a DebounceJobDecorator.
+    expect($job)->toBeInstanceOf(DebounceJobDecorator::class);
+});
+
+it('reads the debounce id from the action property', function () {
+    // When we make a job from the action.
+    $job = AsDebounceJobUsingPropertiesTest::makeJob();
+
+    // Then the debounceId reflects the action's jobDebounceId property.
+    expect($job->debounceId())->toBe('my_debounce_id');
+});

--- a/tests/AsJobWithDebounceJobDecoratorTest.php
+++ b/tests/AsJobWithDebounceJobDecoratorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Support\Facades\Cache;
+use Lorisleiva\Actions\Concerns\AsJob;
+use Lorisleiva\Actions\Decorators\DebounceJobDecorator;
+use Lorisleiva\Actions\Decorators\JobDecorator;
+
+#[DebounceFor(30)]
+class AsJobWithDebounceJobDecoratorTest
+{
+    use AsJob;
+
+    public static ?int $latestResult;
+    public static ?JobDecorator $latestJobDecorator;
+
+    public function handle(int $left, int $right): void
+    {
+        static::$latestResult = $left + $right;
+    }
+
+    public function asJob(DebounceJobDecorator $job, int $left, int $right): void
+    {
+        static::$latestJobDecorator = $job;
+        $this->handle($left, $right);
+    }
+
+    public function getJobDebounceVia(): Repository
+    {
+        return Cache::driver('array');
+    }
+}
+
+beforeEach(function () {
+    // Debounced jobs are only available on Laravel 13.6+.
+    if (! class_exists(DebounceFor::class)) {
+        test()->markTestSkipped('Debounced jobs require Laravel 13.6+.');
+    }
+
+    // Given we reset the static variables.
+    AsJobWithDebounceJobDecoratorTest::$latestResult = null;
+    AsJobWithDebounceJobDecoratorTest::$latestJobDecorator = null;
+});
+
+it('can access the DebounceJobDecorator instance from the asJob method', function () {
+    // When we dispatch a job that expects a DebounceJobDecorator as a first argument.
+    AsJobWithDebounceJobDecoratorTest::dispatch(1, 2);
+
+    // Then it received the DebounceJobDecorator as its first argument.
+    $job = AsJobWithDebounceJobDecoratorTest::$latestJobDecorator;
+    expect($job)->toBeInstanceOf(DebounceJobDecorator::class);
+    expect($job->getParameters())->toBe([1, 2]);
+    expect(get_class($job->getAction()))->toBe(AsJobWithDebounceJobDecoratorTest::class);
+
+    // And it received the expected result.
+    expect(AsJobWithDebounceJobDecoratorTest::$latestResult)->toBe(3);
+});

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -4,12 +4,15 @@ namespace Lorisleiva\Actions\Tests;
 
 use Closure;
 use Illuminate\Console\Application;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\Decorators\JobDecorator;
 use Lorisleiva\Actions\Tests\Stubs\User;
+use ReflectionClass;
 
 function loadMigrations(): void
 {
@@ -47,7 +50,13 @@ function registerCommands(array $commands): void
 
 function assertJobPushed(string $class, ?Closure $callback = null): void
 {
-    Queue::assertPushed(ActionManager::$jobDecorator, function (JobDecorator $job) use ($class, $callback) {
+    $decorator = match (true) {
+        is_subclass_of($class, ShouldBeUnique::class) => ActionManager::$uniqueJobDecorator,
+        class_exists(DebounceFor::class) && (new ReflectionClass($class))->getAttributes(DebounceFor::class) !== [] => ActionManager::$debounceJobDecorator,
+        default => ActionManager::$jobDecorator,
+    };
+
+    Queue::assertPushed($decorator, function (JobDecorator $job) use ($class, $callback) {
         if (! $job->decorates($class)) {
             return false;
         }


### PR DESCRIPTION
## Debounced job support for `AsJob`

Builds on #340 to support Laravel 13.6's `#[DebounceFor]` attribute on actions, following the existing `UniqueJobDecorator` pattern.

Two things this adds on top of #340:

**Forwards `maxWait`.** #340 noted `maxWait` couldn't be forwarded because Laravel reads it directly off the decorator's static attribute. Instead of relying on a dummy attribute, this forwards `debounceFor`/`maxWait` via a `DebouncePendingDispatch` that passes both to `DebounceLock::acquire()`. So `#[DebounceFor(30, maxWait: 60)]` works end to end.

**Rejects unique + debounced.** Core throws if a job is both `ShouldBeUnique` and debounced. This does the same — `makeJob()` throws a `LogicException` with the same message, so it fails fast on every dispatch path. - THis is the same behaviour as Laravel Core - https://github.com/laravel/framework/blob/v13.17.0/src/Illuminate/Foundation/Bus/PendingDispatch.php#L240

### Usage

```php
use Illuminate\Queue\Attributes\DebounceFor;
use Lorisleiva\Actions\Concerns\AsJob;

#[DebounceFor(30, maxWait: 60)]
class SyncUserToMailchimp
{
    use AsJob;

    public function getJobDebounceId(User $user): string
    {
        return (string) $user->id;
    }

    public function handle(User $user): void { /* ... */ }
}
```

@huy-tran Can you take a look at this implementation. Happy to make any improvements you can think of.