### PR TITLE
Fix AsListener not recognized when event implements ShouldDispatchAfterCommit

### DIFF
--- a/src/DesignPatterns/ListenerDesignPattern.php
+++ b/src/DesignPatterns/ListenerDesignPattern.php
@@ -18,6 +18,7 @@ class ListenerDesignPattern extends DesignPattern
     public function recognizeFrame(BacktraceFrame $frame): bool
     {
         return $frame->matches(Dispatcher::class, 'dispatch')
+            || $frame->matches(Dispatcher::class, 'invokeListeners')
             || $frame->matches(Dispatcher::class, 'handlerWantsToBeQueued')
             || $frame->matches(CallQueuedListener::class, 'handle')
             || $frame->matches(CallQueuedListener::class, 'failed');

--- a/tests/AsListenerWithShouldDispatchAfterCommitTest.php
+++ b/tests/AsListenerWithShouldDispatchAfterCommitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Lorisleiva\Actions\Concerns\AsListener;
+use Lorisleiva\Actions\Concerns\AsObject;
+use Lorisleiva\Actions\Tests\Stubs\OperationRequestedAfterCommitEvent;
+
+class AsListenerWithShouldDispatchAfterCommitTest
+{
+    use AsObject;
+    use AsListener;
+
+    public static ?int $latestResult;
+
+    public function handle(int $left, int $right, bool $addition = true): int
+    {
+        return $addition ? $left + $right : $left - $right;
+    }
+
+    public function asListener(OperationRequestedAfterCommitEvent $event): void
+    {
+        static::$latestResult = $this->handle(
+            $event->left,
+            $event->right,
+            $event->operation === 'addition'
+        );
+    }
+}
+
+beforeEach(function () {
+    // Given we are listening for the OperationRequestedAfterCommitEvent.
+    Event::listen(OperationRequestedAfterCommitEvent::class, AsListenerWithShouldDispatchAfterCommitTest::class);
+
+    // And reset the latest result between tests.
+    AsListenerWithShouldDispatchAfterCommitTest::$latestResult = null;
+});
+
+it('works as an object even when the event implements ShouldDispatchAfterCommit', function () {
+    // When we run the action as an object.
+    $result = AsListenerWithShouldDispatchAfterCommitTest::run(5, 3, false);
+
+    // Then we get the expected result.
+    expect($result)->toBe(2);
+
+    // And the `asListener` method was not called.
+    expect(AsListenerWithShouldDispatchAfterCommitTest::$latestResult)->toBeNull();
+});
+
+it('calls asListener() when event implements ShouldDispatchAfterCommit and is dispatched outside a transaction', function () {
+    // When we dispatch the event outside of a transaction.
+    Event::dispatch(new OperationRequestedAfterCommitEvent('addition', 1, 2));
+
+    // Then asListener() was called via the ListenerDecorator.
+    expect(AsListenerWithShouldDispatchAfterCommitTest::$latestResult)->toBe(3);
+});
+
+it('calls asListener() when event implements ShouldDispatchAfterCommit and is dispatched inside a transaction', function () {
+    // When we dispatch the event inside a transaction and commit.
+    DB::beginTransaction();
+    Event::dispatch(new OperationRequestedAfterCommitEvent('addition', 1, 2));
+
+    // Then asListener() has not been called yet (deferred until commit).
+    expect(AsListenerWithShouldDispatchAfterCommitTest::$latestResult)->toBeNull();
+
+    DB::commit();
+
+    // Then asListener() was called via the ListenerDecorator after the commit.
+    expect(AsListenerWithShouldDispatchAfterCommitTest::$latestResult)->toBe(3);
+});

--- a/tests/Stubs/OperationRequestedAfterCommitEvent.php
+++ b/tests/Stubs/OperationRequestedAfterCommitEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lorisleiva\Actions\Tests\Stubs;
+
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+
+class OperationRequestedAfterCommitEvent implements ShouldDispatchAfterCommit
+{
+    public string $operation;
+    public int $left;
+    public int $right;
+
+    public function __construct(string $operation, int $left, int $right)
+    {
+        $this->operation = $operation;
+        $this->left = $left;
+        $this->right = $right;
+    }
+}


### PR DESCRIPTION
## Problem

When an event implements `ShouldDispatchAfterCommit` and is dispatched inside an active database transaction, the `ListenerDecorator` is never applied. Laravel ends up calling `handle()` directly with the raw event object instead of going through `asListener()` or resolving typed dependencies.

**Minimal reproduction:**

```php
class UploadStatusChanged implements ShouldDispatchAfterCommit
{
    public function __construct(public Upload $upload) {}
}

class HandleUploadStatusChanged
{
    use AsListener, AsObject;

    public function handle(Upload $upload): void { /* ... */ }

    public function asListener(UploadStatusChanged $event): void
    {
        $this->handle($event->upload);
    }
}

Event::listen(UploadStatusChanged::class, HandleUploadStatusChanged::class);

DB::beginTransaction();
Event::dispatch(new UploadStatusChanged($upload));
DB::commit(); // ← asListener() is never called; handle() receives the event object
```

## Root Cause

`ListenerDesignPattern::recognizeFrame()` detects the listener context by scanning the call stack for `Dispatcher::dispatch`. This works for normal dispatches.

However, for `ShouldDispatchAfterCommit` events inside a transaction, Laravel 12 defers execution via a stored callback:

```php
// Dispatcher::dispatch()
$transactions->addCallback(
    fn () => $this->invokeListeners($parsedEvent, $parsedPayload, $halt)
);
return null; // dispatch() exits here, stack is unwound
```

When the transaction commits and the callback fires, `Dispatcher::dispatch` is no longer on the call stack. `recognizeFrame()` finds no match, no decorator is applied, and the action falls back to being called as a plain object.

## Fix

Add `Dispatcher::invokeListeners` to the recognized frames. It is the convergence point for both dispatch paths in Laravel 12:

```php
// Normal path
return $this->invokeListeners($parsedEvent, $parsedPayload, $halt);

// ShouldDispatchAfterCommit path
$transactions->addCallback(fn () => $this->invokeListeners(...));
```

`invokeListeners` is a protected method specific to event dispatching. It does not appear in controller (`Route::getController`) or command (`Application::resolve`) call stacks, so the change does not affect other design patterns.

## Changes

- `src/DesignPatterns/ListenerDesignPattern.php` — add `Dispatcher::invokeListeners` to `recognizeFrame()`
- `tests/AsListenerWithShouldDispatchAfterCommitTest.php` — new test covering object use, dispatch outside a transaction, and dispatch inside a committed transaction
- `tests/Stubs/OperationRequestedAfterCommitEvent.php` — event stub implementing `ShouldDispatchAfterCommit`

Closes #345