### PR TITLE
Add root PHPStan configuration at level 5

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,9 +19,9 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl
           coverage: none
 
-      # Analysis runs on a single dependency set. The baseline records line
-      # numbers and inferred types, so a prefer-lowest resolution would report
-      # errors that do not match it.
+      # Analysis runs on a single dependency set. Larastan infers different
+      # types across Laravel versions, so a prefer-lowest resolution would
+      # report errors the configuration does not account for.
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,29 @@
+name: PHPStan
+
+on: [push, pull_request]
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    name: PHPStan
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl
+          coverage: none
+
+      # Analysis runs on a single dependency set. The baseline records line
+      # numbers and inferred types, so a prefer-lowest resolution would report
+      # errors that do not match it.
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build
 composer.lock
 coverage
 docs
+phpstan.neon
 phpunit.xml
 psalm.xml
 vendor

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,13 @@
         "lorisleiva/lody": "^0.7"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "larastan/larastan": "^3.0",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^3.0|^4.0",
+        "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^11.5|^12.0"
     },
     "autoload": {
@@ -46,13 +50,15 @@
         ]
     },
     "scripts": {
+        "phpstan": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest --colors=always",
         "test-coverage": "vendor/bin/pest --coverage-html coverage"
     },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
         }
     },
     "extra": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,62 @@
+includes:
+    # Larastan, Pest, Carbon and phpstan-phpunit register themselves through
+    # phpstan/extension-installer. The root package's own extension does not.
+    - extension.neon
+
+parameters:
+    level: 5
+    paths:
+        - src
+        - tests
+    excludePaths:
+        analyse:
+            # Deliberately invalid calls that the rule's own tests assert against.
+            - tests/PHPStan/Fixtures
+
+    # Pest shares state between hooks and tests by assigning arbitrary
+    # properties onto $this, which it types as a TestCall.
+    universalObjectCratesClasses:
+        - Pest\PendingCalls\TestCall
+
+    ignoreErrors:
+        # Pest's test() returns a TestCall that forwards every unknown method to
+        # the underlying TestCase through __call.
+        -
+            identifier: method.notFound
+            message: '#Call to an undefined method .*Pest\\.*::#'
+            path: tests/*
+
+        # Mockery's fluent expectations are typed as a union that only one half
+        # of implements.
+        -
+            identifier: method.notFound
+            message: '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/*
+
+        # The concerns call handle(), which the concrete action supplies. A
+        # @method tag on the trait would resolve this, but it would also make
+        # hasMethod('handle') true everywhere and silence
+        # laravelActions.missingHandle.
+        -
+            identifier: method.notFound
+            message: '#Call to an undefined method .*::handle\(\)#'
+            path: src/Concerns/*
+
+        # An action may declare a void handle(), which __invoke() still returns.
+        # Reported once per such action, so it cannot be baselined.
+        -
+            identifier: method.void
+            path: src/Concerns/AsController.php
+
+        # FormRequest annotates $validator as non-nullable even though it stays
+        # null until getValidatorInstance() populates it, so PHPStan reads the
+        # null check as always true.
+        -
+            identifier: deadCode.unreachable
+            path: src/Concerns/ValidateActions.php
+
+        # Testing a throw type extension means running PHPStan's own rules, which
+        # sit outside its backward compatibility promise.
+        -
+            identifier: phpstanApi.classConstant
+            path: tests/PHPStan/*

--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -3,7 +3,6 @@
 namespace Lorisleiva\Actions;
 
 use Illuminate\Console\Application as Artisan;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Lorisleiva\Actions\Concerns\AsCommand;
@@ -19,7 +18,7 @@ class ActionManager
     /** @var class-string<JobDecorator> */
     public static string $jobDecorator = JobDecorator::class;
 
-    /** @var class-string<JobDecorator&ShouldBeUnique> */
+    /** @var class-string<UniqueJobDecorator> */
     public static string $uniqueJobDecorator = UniqueJobDecorator::class;
 
     /** @var DesignPattern[] */
@@ -44,7 +43,7 @@ class ActionManager
     }
 
     /**
-     * @param class-string<JobDecorator&ShouldBeUnique> $uniqueJobDecoratorClass
+     * @param class-string<UniqueJobDecorator> $uniqueJobDecoratorClass
      */
     public static function useUniqueJobDecorator(string $uniqueJobDecoratorClass): void
     {

--- a/src/ActionManager.php
+++ b/src/ActionManager.php
@@ -141,8 +141,8 @@ class ActionManager
             debug_backtrace($backtraceOptions, $ownNumberOfFrames + $this->backtraceLimit),
             $ownNumberOfFrames
         );
-        foreach ($frames as $frame) {
-            $frame = new BacktraceFrame($frame);
+        foreach ($frames as $rawFrame) {
+            $frame = new BacktraceFrame($rawFrame);
 
             /** @var DesignPattern $designPattern */
             foreach ($designPatterns as $designPattern) {

--- a/src/ActionPendingChain.php
+++ b/src/ActionPendingChain.php
@@ -10,14 +10,16 @@ class ActionPendingChain extends PendingChain
 {
     public function dispatch(): ?PendingDispatch
     {
-        /** @var $job AsJob */
-        if ($this->usesAsJobTrait($job = $this->job)) {
+        $job = $this->job;
+
+        if ($this->usesAsJobTrait($job)) {
             $this->job = $job::makeJob(...func_get_args());
         }
 
         return parent::dispatch();
     }
 
+    /** @phpstan-assert-if-true class-string $job */
     public function usesAsJobTrait($job): bool
     {
         return is_string($job)

--- a/src/AttributeValidator.php
+++ b/src/AttributeValidator.php
@@ -5,6 +5,7 @@ namespace Lorisleiva\Actions;
 use Illuminate\Routing\Redirector;
 use Lorisleiva\Actions\Concerns\ValidateActions;
 
+/** @phpstan-consistent-constructor */
 class AttributeValidator
 {
     use ValidateActions;

--- a/src/Concerns/AsJob.php
+++ b/src/Concerns/AsJob.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Testing\Fakes\QueueFake;
 use Lorisleiva\Actions\ActionManager;
 use Lorisleiva\Actions\ActionPendingChain;
 use Lorisleiva\Actions\Decorators\JobDecorator;
@@ -116,7 +117,11 @@ trait AsJob
             ? ActionManager::$uniqueJobDecorator
             : ActionManager::$jobDecorator;
 
-        $count = Queue::pushed($decoratorClass, function (JobDecorator $job, $queue) use ($callback) {
+        // pushed() only exists once the queue has been faked.
+        /** @var QueueFake $fake */
+        $fake = Queue::getFacadeRoot();
+
+        $count = $fake->pushed($decoratorClass, function (JobDecorator $job, $queue) use ($callback) {
             if (! $job->decorates(static::class)) {
                 return false;
             }

--- a/src/Concerns/ValidateActions.php
+++ b/src/Concerns/ValidateActions.php
@@ -106,7 +106,9 @@ trait ValidateActions
     protected function failedValidation(Validator $validator)
     {
         if ($this->hasMethod('getValidationFailure')) {
-            return $this->resolveAndCallMethod('getValidationFailure', compact('validator'));
+            $this->resolveAndCallMethod('getValidationFailure', compact('validator'));
+
+            return;
         }
 
         throw (new ValidationException($validator))
@@ -166,7 +168,7 @@ trait ValidateActions
     protected function prepareForValidation()
     {
         if ($this->hasMethod('prepareForValidation')) {
-            return $this->resolveAndCallMethod('prepareForValidation');
+            $this->resolveAndCallMethod('prepareForValidation');
         }
     }
 }

--- a/src/Decorators/JobDecorator.php
+++ b/src/Decorators/JobDecorator.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
 use Lorisleiva\Actions\Concerns\DecorateActions;
 use ReflectionMethod;
-use ReflectionParameter;
 use Throwable;
 
 class JobDecorator implements ShouldQueue
@@ -165,8 +164,9 @@ class JobDecorator implements ShouldQueue
             return $this->parameters;
         }
 
-        /** @var ReflectionParameter $firstParameter */
-        if (! $firstParameter = Arr::first($reflectionMethod->getParameters())) {
+        $firstParameter = Arr::first($reflectionMethod->getParameters());
+
+        if (! $firstParameter) {
             return $this->parameters;
         }
 

--- a/tests/ActionManagerTest.php
+++ b/tests/ActionManagerTest.php
@@ -10,13 +10,13 @@ use Lorisleiva\Actions\Tests\Stubs\CustomUniqueJobDecorator;
 it('resolves from the container', function () {
     $manager = app(ActionManager::class);
 
-    expect($manager instanceof ActionManager)->toBeTrue();
+    expect($manager)->toBeInstanceOf(ActionManager::class);
 });
 
 it('resolves as a Facade', function () {
     $manager = Actions::getFacadeRoot();
 
-    expect($manager instanceof ActionManager)->toBeTrue();
+    expect($manager)->toBeInstanceOf(ActionManager::class);
 });
 
 it('resolves as a singleton', function () {

--- a/tests/AsActionWithValidatedAttributesTest.php
+++ b/tests/AsActionWithValidatedAttributesTest.php
@@ -12,6 +12,11 @@ use Lorisleiva\Actions\Concerns\AsAction;
 use Lorisleiva\Actions\Concerns\WithAttributes;
 use Lorisleiva\Actions\Tests\Stubs\OperationRequestedEvent;
 
+/**
+ * @property string $operation
+ * @property int $left
+ * @property int $right
+ */
 class AsActionWithValidatedAttributesTest
 {
     use AsAction;

--- a/tests/AsCommandTest.php
+++ b/tests/AsCommandTest.php
@@ -15,9 +15,12 @@ class AsCommandTest
     {
         static::$decorator = $command;
 
+        $left = (int) $command->argument('left');
+        $right = (int) $command->argument('right');
+
         $result = ($command->hasOption('sub') && $command->option('sub'))
-            ? $command->argument('left') - $command->argument('right')
-            : $command->argument('left') + $command->argument('right');
+            ? $left - $right
+            : $left + $right;
 
         $command->line("Result: {$result}");
     }

--- a/tests/AsCommandUsingPropertiesTest.php
+++ b/tests/AsCommandUsingPropertiesTest.php
@@ -20,9 +20,12 @@ class AsCommandUsingPropertiesTest
     {
         static::$decorator = $command;
 
+        $left = (int) $command->argument('left');
+        $right = (int) $command->argument('right');
+
         $result = ($command->hasOption('sub') && $command->option('sub'))
-            ? $command->argument('left') - $command->argument('right')
-            : $command->argument('left') + $command->argument('right');
+            ? $left - $right
+            : $left + $right;
 
         $command->line("Result: {$result}");
     }

--- a/tests/AsControllerTest.php
+++ b/tests/AsControllerTest.php
@@ -75,5 +75,5 @@ it('constructs the action and runs the handle method exactly once per request', 
 it('provides a magic invoke method to enable the action to be registered as a route', function () {
     // When an action uses the `AsController` trait.
     // Then it has the `__invoke` method.
-    expect(method_exists(AsControllerTest::class, '__invoke'))->toBeTrue();
+    expect(AsControllerTest::class)->toHaveMethod('__invoke');
 });

--- a/tests/AsControllerWithValidatedAttributesTest.php
+++ b/tests/AsControllerWithValidatedAttributesTest.php
@@ -7,6 +7,11 @@ use Lorisleiva\Actions\ActionRequest;
 use Lorisleiva\Actions\Concerns\AsController;
 use Lorisleiva\Actions\Concerns\WithAttributes;
 
+/**
+ * @property string $operation
+ * @property int $left
+ * @property int $right
+ */
 class AsControllerWithValidatedAttributesTest
 {
     use AsController;

--- a/tests/AsObjectWithValidatedAttributesTest.php
+++ b/tests/AsObjectWithValidatedAttributesTest.php
@@ -7,6 +7,11 @@ use Illuminate\Validation\ValidationException;
 use Lorisleiva\Actions\Concerns\AsObject;
 use Lorisleiva\Actions\Concerns\WithAttributes;
 
+/**
+ * @property string $operation
+ * @property int $left
+ * @property int $right
+ */
 class AsObjectWithValidatedAttributesTest
 {
     use AsObject;


### PR DESCRIPTION
Adds a root `phpstan.neon.dist` at level 5 so the package analyses itself, including the extension from #338. Adds `larastan/larastan`, `phpstan/phpstan-phpunit` and `phpstan/extension-installer`, and runs PHPStan in CI.

Builds on #338, so the diff includes its commits until that merges.

Level 5 rather than higher because level 6 takes it from 15 to 187 errors, nearly all `missingType.*` on unannotated signatures.

Getting to a clean run needed some type declaration fixes across `src` and three test files. No runtime behaviour changes. The one worth calling out: `ActionManager::$uniqueJobDecorator` was annotated `class-string<JobDecorator&ShouldBeUnique>` while `makeUniqueJob()` returns `UniqueJobDecorator`, so a custom decorator implementing `ShouldBeUnique` without extending `UniqueJobDecorator` would have violated the declared return type.

Also declares `friendsofphp/php-cs-fixer` in `require-dev`. It was installed and present in the lock but never declared, so `composer validate` flagged the lock as stale and `composer update` dropped it.
